### PR TITLE
Adding some Rat excludes.

### DIFF
--- a/nbbuild/build.xml
+++ b/nbbuild/build.xml
@@ -1950,6 +1950,10 @@ It is possible to use -Ddebug.port=3234 -Ddebug.pause=y to start the system in d
             <fileset dir="${nb_all}">
                 <exclude name="*/build/**" />
                 <exclude name="nbbuild/netbeans/**" />
+                <exclude name="**/manifest.mf" /> <!--do not nativelly support comments-->
+                <exclude name="*/nbproject/*.sig" /> <!--generated signatures for past versions-->
+                <exclude name="*/external/*-license.txt" /> <!--licenses for external dependencies-->
+                <exclude name="*/external/*-notice.txt" /> <!--notices for external dependencies-->
             </fileset>
         </rat:report>
     </target>


### PR DESCRIPTION
Adding some Rat excludes, for manifests, sig files (automatically generated), license and notice files.