### PR TITLE
Fixes bug in FileChooserBuilderTest

### DIFF
--- a/openide.filesystems.nb/test/unit/src/org/openide/filesystems/FileChooserBuilderTest.java
+++ b/openide.filesystems.nb/test/unit/src/org/openide/filesystems/FileChooserBuilderTest.java
@@ -173,7 +173,7 @@ public class FileChooserBuilderTest extends NbTestCase {
         FileChooserBuilder instance = new FileChooserBuilder("i");
         File tmp = new File(System.getProperty("java.io.tmpdir"));
         assertTrue ("Environment is insane", tmp.exists() && tmp.isDirectory());
-        File sel = new File("tmp" + System.currentTimeMillis());
+        File sel = new File(tmp, "tmp" + System.currentTimeMillis());
         if (!sel.exists()) {
             assertTrue (sel.createNewFile());
         }

--- a/openide.filesystems.nb/test/unit/src/org/openide/filesystems/FileChooserBuilderTest.java
+++ b/openide.filesystems.nb/test/unit/src/org/openide/filesystems/FileChooserBuilderTest.java
@@ -171,7 +171,7 @@ public class FileChooserBuilderTest extends NbTestCase {
 
     public void testSetSelectionApprover() throws Exception {
         FileChooserBuilder instance = new FileChooserBuilder("i");
-        File tmp = new File(System.getProperty("java.io.tmpdir"));
+        File tmp = getWorkDir();
         assertTrue ("Environment is insane", tmp.exists() && tmp.isDirectory());
         File sel = new File(tmp, "tmp" + System.currentTimeMillis());
         if (!sel.exists()) {


### PR DESCRIPTION
The tmpdir is loaded but the temporary file is not created in it, resulting on macOS in a Permission denied IOException because java cannot write on root (/). The fix just places the temporary file in java.io.tmpdir as it was probably intended.