### PR TITLE
[NETBEANS-54] Module Review db.sql.visualeditor

### DIFF
--- a/db.sql.visualeditor/external/binaries-list
+++ b/db.sql.visualeditor/external/binaries-list
@@ -1,1 +1,17 @@
-EE416CB5D6AA88473EFE487F42DC1410360F7948 javacc-3.2.jar
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+EE416CB5D6AA88473EFE487F42DC1410360F7948 net.java.dev.javacc:javacc:3.2


### PR DESCRIPTION
- external library javacc is only used at build time and is not
  distributed with netbeans

- modified binaries-list to point to maven coordinates

- checked Rat report; missing headers added, ignored *.form 
  (see central problems)

- skimmed through the module, did not notice additional problems