### PR TITLE
[NETBEANS-54] Module Review derby

### DIFF
--- a/derby/etc/sample.sql
+++ b/derby/etc/sample.sql
@@ -1,3 +1,20 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+--
 -- Script to create the Java DB sample database. Run in the db/external directory using:
 --
 -- java -cp $DERBY_HOME/lib/derbytools.jar:$DERBY_HOME/lib/derby.jar org.apache.derby.tools.ij ../derby/etc/sample.sql


### PR DESCRIPTION
- external binary is binary form of etc/sample.sql (not on maven)

- checked Rat report; missing header added to etc/sample.sql, ignored
  binaries-list and *.form files (see central problems)

- skimmed through the module, did not notice additional problems

- replacing the bundled binary is tracked by [NETBEANS-74]