### PR TITLE
-external library jna-platform-4.2.2.jar: dual-licensed by Apache Lic…

### DIFF
--- a/libs.jna.platform/external/binaries-list
+++ b/libs.jna.platform/external/binaries-list
@@ -1,1 +1,18 @@
-030FA67B23CF2C0327A02CFAECBEF76A20160E7B jna-platform-4.2.2.jar
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+030FA67B23CF2C0327A02CFAECBEF76A20160E7B net.java.dev.jna:jna-platform:4.2.2

--- a/libs.jna.platform/external/jna-platform-4.2.2-license.txt
+++ b/libs.jna.platform/external/jna-platform-4.2.2-license.txt
@@ -1,7 +1,6 @@
 Name: Java Native Access
-Version: 4.2.1
+Version: 4.2.2
 License: Apache-2.0
-OSR: 7755
 Description: Dynamically access native libraries from Java without JNI.
 
                                  Apache License


### PR DESCRIPTION
…ense v2.0 and GPLv2, picking Apache License. NOTICE entry does not seem to be needed. Maven coordinates added.

-checked Rat report; no license header in binaries-list (added)

-fixed version in -license.txt

-skimmed through the module, did not notice additional problems