### PR TITLE
-external library Apache felix. Changed coordinates to Maven. File na…

### DIFF
--- a/libs.felix/external/binaries-list
+++ b/libs.felix/external/binaries-list
@@ -1,1 +1,18 @@
-1BA97A9FFD4A1DFF3E75B76CD3AE3D0EFF8493B7 felix-4.2.1.jar
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+1BA97A9FFD4A1DFF3E75B76CD3AE3D0EFF8493B7 org.apache.felix:org.apache.felix.main:4.2.1

--- a/libs.felix/external/org.apache.felix.main-4.2.1-license.txt
+++ b/libs.felix/external/org.apache.felix.main-4.2.1-license.txt
@@ -1,9 +1,8 @@
 Name: Felix
-Version: 4.0.2
+Version: 4.2.1
 Description: Apache Felix OSGi container.
 License: Apache-2.0
-OSR: Oracle-7595
-Files: felix-4.0.2.jar
+Files: org.apache.felix.main-4.2.1.jar
 Origin: http://archive.apache.org/dist/felix/
 
                                  Apache License

--- a/libs.felix/external/org.apache.felix.main-4.2.1-notice.txt
+++ b/libs.felix/external/org.apache.felix.main-4.2.1-notice.txt
@@ -1,0 +1,8 @@
+
+Apache Felix Main
+Copyright 2006-2013 The Apache Software Foundation
+
+This product includes software developed at
+The OSGi Alliance (http://www.osgi.org/).
+Copyright (c) OSGi Alliance (2000, 2012).
+Licensed under the Apache License 2.0.

--- a/libs.felix/nbproject/project.properties
+++ b/libs.felix/nbproject/project.properties
@@ -15,6 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-release.external/felix-4.2.1.jar=modules/ext/felix-4.2.1.jar
+release.external/org.apache.felix.main-4.2.1.jar=modules/ext/org.apache.felix.main-4.2.1.jar
 javac.source=1.6
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/libs.felix/nbproject/project.xml
+++ b/libs.felix/nbproject/project.xml
@@ -36,8 +36,8 @@
             </module-dependencies>
             <public-packages/>
             <class-path-extension>
-                <runtime-relative-path>ext/felix-4.2.1.jar</runtime-relative-path>
-                <binary-origin>external/felix-4.2.1.jar</binary-origin>
+                <runtime-relative-path>ext/org.apache.felix.main-4.2.1.jar</runtime-relative-path>
+                <binary-origin>external/org.apache.felix.main-4.2.1.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>


### PR DESCRIPTION
…me changed, adjusted. License Apache License v2.0. -notice.txt added based on NOTICE from Felix.

-checked Rat report; no license header in binaries-list (added)

-fixed version in -license.txt

-skimmed through the module, did not notice additional problems