### PR TITLE
[NETBEANS-54] Module Review api.xml

### DIFF
--- a/api.xml/test/unit/src/org/netbeans/api/xml/parsers/data/Entity.dtd
+++ b/api.xml/test/unit/src/org/netbeans/api/xml/parsers/data/Entity.dtd
@@ -1,3 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 
 <!NOTATION notation SYSTEM "test">

--- a/api.xml/test/unit/src/org/netbeans/api/xml/parsers/data/RelativeTest.dtd
+++ b/api.xml/test/unit/src/org/netbeans/api/xml/parsers/data/RelativeTest.dtd
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 
 <!--
     Document   : RelativeTest.dtd


### PR DESCRIPTION
- no external library
- checked Rat report: add the license header in two *.dtd. ignore three package-list[1] files, org-netbeans-api-xml.sig
- A unit test fails even if the license header is not added. (ClassNotFoundException: org.apache.crimson.parser.XMLReaderImpl)

[1] http://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html#JSWOR663
