### PR TITLE
added initial .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: java
+    # specifying other dists doesn't make sense because `trusty` doesn't have `oraclejdk8` (fails due to `Sorry, but JDK '[oraclejdk8]' is not known.`) which is the only supported JDK currently. Testing on Mac OSX doesn't make too much sense since it will run the same `maven` based build routine.
+
+jdk:
+- oraclejdk8
+- oraclejdk9
+- openjdk8
+# Java 7-JDKs not supported by build
+
+install: /bin/true
+
+script:
+- ant > /tmp/netbeans-build.log || tail -n 10000 /tmp/netbeans-build.log
+- ant -Dcluster.config=platform > /tmp/netbeans-platform-build.log || tail -n 10000 /tmp/netbeans-platform-build.log


### PR DESCRIPTION
A basic `.travis.yml` to test the build instructions specified in `README.md`.