### PR TITLE
[NETBEANS-54] Module Review lexer.nbbridge

### DIFF
--- a/lexer.nbbridge/test/unit/src/org/netbeans/modules/lexer/nbbridge/test/testLayer.xml
+++ b/lexer.nbbridge/test/unit/src/org/netbeans/modules/lexer/nbbridge/test/testLayer.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <!DOCTYPE filesystem PUBLIC "-//NetBeans//DTD Filesystem 1.1//EN" "http://www.netbeans.org/dtds/filesystem-1_1.dtd">
 <filesystem>
     <folder name="Editors">


### PR DESCRIPTION
  - No external libraries.
  - One test failed: org.netbeans.modules.lexer.nbbridge.test.MimeLookupLanguageProv
  - Added license to a single layer.xml test file (not strictly required).