### PR TITLE
[NETBEANS-54] Module Review libs.antlr4.runtime

### DIFF
--- a/libs.antlr4.runtime/external/binaries-list
+++ b/libs.antlr4.runtime/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-2609E36F18F7E8D593CC1CDDFB2AC776DC96B8E0 antlr-runtime-4.5.3.jar
+2609E36F18F7E8D593CC1CDDFB2AC776DC96B8E0 org.antlr:antlr4-runtime:4.5.3


### PR DESCRIPTION
  - Updated maven coordinates for antlr 4.5.3 (BSD)
  - No other problems found.