### PR TITLE
[NETBEANS-54] Module Review libs.ini4j

### DIFF
--- a/libs.ini4j/external/binaries-list
+++ b/libs.ini4j/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-8E737D82ECAC9BA6100A9BBA71E92A381B75EFDC ini4j-0.5.1.jar
+8E737D82ECAC9BA6100A9BBA71E92A381B75EFDC org.ini4j:ini4j:0.5.1


### PR DESCRIPTION
  - Updated maven coordinates for ini4j 0.5.1 (Apache 2)
  - All license headers are correct.