### PR TITLE
[NETBEANS-54] Module Review - Resolves #65 - html.editor.lib

### DIFF
--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/ProblemDescription.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/ProblemDescription.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
+ 
 package org.netbeans.modules.html.editor.lib.api;
 
 public final class ProblemDescription {

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/ProblemDescription.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/ProblemDescription.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
- 
+
 package org.netbeans.modules.html.editor.lib.api;
 
 public final class ProblemDescription {

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/ProblemDescription.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/ProblemDescription.java
@@ -1,44 +1,22 @@
-/*
- * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- * Copyright 1997-2010 Oracle and/or its affiliates. All rights reserved.
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Oracle and Java are registered trademarks of Oracle and/or its affiliates.
- * Other names may be trademarks of their respective owners.
- *
- * The contents of this file are subject to the terms of either the GNU
- * General Public License Version 2 only ("GPL") or the Common
- * Development and Distribution License("CDDL") (collectively, the
- * "License"). You may not use this file except in compliance with the
- * License. You can obtain a copy of the License at
- * http://www.netbeans.org/cddl-gplv2.html
- * or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
- * specific language governing permissions and limitations under the
- * License.  When distributing the software, include this License Header
- * Notice in each file and include the License file at
- * nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the GPL Version 2 section of the License file that
- * accompanied this code. If applicable, add the following below the
- * License Header, with the fields enclosed by brackets [] replaced by
- * your own identifying information:
- * "Portions Copyrighted [year] [name of copyright owner]"
- *
- * If you wish your version of this file to be governed by only the CDDL
- * or only the GPL Version 2, indicate your decision by adding
- * "[Contributor] elects to include this software in this distributigon
- * under the [CDDL or GPL Version 2] license." If you do not indicate a
- * single choice of license, a recipient has the option to distribute
- * your version of this file under either the CDDL, the GPL Version 2 or
- * to extend the choice of license to its licensees as provided above.
- * However, if you add GPL Version 2 code and therefore, elected the GPL
- * Version 2 license, then the option applies only if the new code is
- * made subject to such option by the copyright holder.
- *
- * Contributor(s):
- *
- * Portions Copyrighted 2008 Sun Microsystems, Inc.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
+
 package org.netbeans.modules.html.editor.lib.api;
 
 public final class ProblemDescription {
@@ -48,7 +26,7 @@ public final class ProblemDescription {
     public static final int ERROR = 2;
     public static final int FATAL = 3;
     public static final int INTERNAL_ERROR = 4;
-    
+
     private String key;
     private String text;
     private int from;
@@ -63,7 +41,7 @@ public final class ProblemDescription {
         assert from >= 0;
         assert to >= 0;
         assert from <= to;
-        
+
         this.key = key;
         this.text = text;
         this.type = type;

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/elements/Node.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/elements/Node.java
@@ -1,61 +1,39 @@
-/*
- * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- * Copyright 1997-2010 Oracle and/or its affiliates. All rights reserved.
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Oracle and Java are registered trademarks of Oracle and/or its affiliates.
- * Other names may be trademarks of their respective owners.
- *
- * The contents of this file are subject to the terms of either the GNU
- * General Public License Version 2 only ("GPL") or the Common
- * Development and Distribution License("CDDL") (collectively, the
- * "License"). You may not use this file except in compliance with the
- * License. You can obtain a copy of the License at
- * http://www.netbeans.org/cddl-gplv2.html
- * or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
- * specific language governing permissions and limitations under the
- * License.  When distributing the software, include this License Header
- * Notice in each file and include the License file at
- * nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the GPL Version 2 section of the License file that
- * accompanied this code. If applicable, add the following below the
- * License Header, with the fields enclosed by brackets [] replaced by
- * your own identifying information:
- * "Portions Copyrighted [year] [name of copyright owner]"
- *
- * If you wish your version of this file to be governed by only the CDDL
- * or only the GPL Version 2, indicate your decision by adding
- * "[Contributor] elects to include this software in this distributigon
- * under the [CDDL or GPL Version 2] license." If you do not indicate a
- * single choice of license, a recipient has the option to distribute
- * your version of this file under either the CDDL, the GPL Version 2 or
- * to extend the choice of license to its licensees as provided above.
- * However, if you add GPL Version 2 code and therefore, elected the GPL
- * Version 2 license, then the option applies only if the new code is
- * made subject to such option by the copyright holder.
- *
- * Contributor(s):
- *
- * Portions Copyrighted 2008 Sun Microsystems, Inc.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
+
 package org.netbeans.modules.html.editor.lib.api.elements;
 
 import java.util.Collection;
 
 
 /**
- * 
+ *
  * @author marekfukala
  */
 public interface Node extends Element {
-    
+
     public Collection<Element> children();
-    
+
     public Collection<Element> children(ElementType type);
-    
+
     public Collection<Element> children(ElementFilter filter);
-    
+
     public <T extends Element> Collection<T> children(Class<T> type);
-    
+
 }

--- a/html.editor.lib/test/unit/data/input/HTMLCompletionQueryTest/index.html
+++ b/html.editor.lib/test/unit/data/input/HTMLCompletionQueryTest/index.html
@@ -1,10 +1,25 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
 <html>
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" >
         <title>A page</title>
-    
+
         <style type="text/css">
             #search {height:100%;}
             #topmodule {align:right;}
@@ -18,7 +33,7 @@ function get_sc_login() {
 var username=get_sc_login();
 //-->
         </script>
-    
+
     </head>
     <body>
         <div> &amp; </div>
@@ -35,8 +50,8 @@ var username=get_sc_login();
                 </td>
             </tr>
         </table>
-  
+
         <div @ err="true"/>
-        
+
     </body>
 </html>

--- a/html.editor.lib/test/unit/data/input/HTMLCompletionQueryTest/truncated_netbeans_front_page.html
+++ b/html.editor.lib/test/unit/data/input/HTMLCompletionQueryTest/truncated_netbeans_front_page.html
@@ -1,15 +1,31 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
 <html>
-           
- 
+
+
  <head>
      <script src="/branding/scripts/tigris.js" type="text/javascript"></script>
      <link rel="stylesheet" type="text/css" href="http://www.netbeans.org/netbeans.css">
- 
+
      <title>
          Welcome to NetBeans
      </title>
-     
+
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" >
 <meta http-equiv="Content-Style-Type" content="text/css" >
 <meta name="SourceCastVersion" content="2.6.2.4.10" >
@@ -44,10 +60,10 @@ var username=get_sc_login();
 //-->
      </script>
  </head>
- 
- 
+
+
     <body onload="loginfocus()" class="composite">
- 
+
         <table border="0" cellspacing="0" cellpadding="0" width="100%">
         <tr>
             <td colspan="2" nowrap>
@@ -86,6 +102,6 @@ var username=get_sc_login();
         <!-- /Servlet-Specific template -->
 
         <!-- servlets and anything not on www or testwww -->
- 
+
     </body>
 </html>

--- a/html.editor.lib/test/unit/data/input/HTMLSyntaxSupportTest/index.html
+++ b/html.editor.lib/test/unit/data/input/HTMLSyntaxSupportTest/index.html
@@ -1,10 +1,25 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
 <html>
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" >
         <title>A page</title>
-    
+
         <style type="text/css">
             #search {height:100%;}
             #topmodule {align:right;}
@@ -18,7 +33,7 @@ function get_sc_login() {
 var username=get_sc_login();
 //-->
         </script>
-    
+
     </head>
     <body>
         <div> &amp; </div>
@@ -35,8 +50,8 @@ var username=get_sc_login();
                 </td>
             </tr>
         </table>
-  
+
         <div @ err="true"/>
-        
+
     </body>
 </html>

--- a/html.editor.lib/test/unit/data/testfiles/syntaxtree/issues145821.html
+++ b/html.editor.lib/test/unit/data/testfiles/syntaxtree/issues145821.html
@@ -1,3 +1,19 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
 <table width="100%">
     <table>
         <table>

--- a/html.editor.lib/test/unit/data/testfiles/syntaxtree/list.html
+++ b/html.editor.lib/test/unit/data/testfiles/syntaxtree/list.html
@@ -1,3 +1,19 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
 <ul>
     <li>
     <li></li>

--- a/html.editor.lib/test/unit/data/testfiles/syntaxtree/missingEndTag.html
+++ b/html.editor.lib/test/unit/data/testfiles/syntaxtree/missingEndTag.html
@@ -1,3 +1,19 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
 <table>
     <tr>
         <a>

--- a/html.editor.lib/test/unit/data/testfiles/syntaxtree/table.html
+++ b/html.editor.lib/test/unit/data/testfiles/syntaxtree/table.html
@@ -1,3 +1,19 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
 <table>
     <tr>
         <td>

--- a/html.editor.lib/test/unit/data/testfiles/syntaxtree/tagCrossing.html
+++ b/html.editor.lib/test/unit/data/testfiles/syntaxtree/tagCrossing.html
@@ -1,3 +1,19 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
     <p>
        <a>
     </p>

--- a/html.editor.lib/test/unit/data/testfiles/syntaxtree/trivial.html
+++ b/html.editor.lib/test/unit/data/testfiles/syntaxtree/trivial.html
@@ -1,3 +1,19 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
 <html>
     <body>
         Hello, world!!!


### PR DESCRIPTION
Replaces license header with apache standard.

If there is a problem with the formatting changes caused by my text editor let me know and I can adjust any of those files.