### PR TITLE
Not all tests can be compiled right now. Compile them as part of travis run.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 /*/external/*/**
 /nbbuild/netbeans/
 /nbbuild/testuserdir/
+/nbbuild/*.zip
 /nbbuild/user.build.properties
 /nbi/engine/native/*/*/dist/
 /nb-javac/

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,4 @@ jdk:
   - oraclejdk8
 script:
   - ant -quiet build -Djavac.compilerargs=-nowarn -Dbuild.compiler.deprecation=false
-
-
+  - ant -quiet test -Djavac.compilerargs=-nowarn -Dbuild.compiler.deprecation=false -Dtest.includes=NoTestsJustBuild

--- a/spring.beans/nbproject/project.xml
+++ b/spring.beans/nbproject/project.xml
@@ -500,10 +500,6 @@
                 <test-type>
                     <name>unit</name>
                     <test-dependency>
-                        <code-name-base>org.netbeans.api.web.webmodule</code-name-base>
-                        <compile-dependency/>
-                    </test-dependency>
-                    <test-dependency>
                         <code-name-base>org.netbeans.libs.junit4</code-name-base>
                         <compile-dependency/>
                     </test-dependency>
@@ -518,15 +514,6 @@
                     </test-dependency>
                     <test-dependency>
                         <code-name-base>org.netbeans.modules.editor.mimelookup.impl</code-name-base>
-                    </test-dependency>
-                    <test-dependency>
-                        <code-name-base>org.netbeans.modules.j2ee.core</code-name-base>
-                        <compile-dependency/>
-                    </test-dependency>
-                    <test-dependency>
-                        <code-name-base>org.netbeans.modules.j2ee.dd</code-name-base>
-                        <recursive/>
-                        <compile-dependency/>
                     </test-dependency>
                     <test-dependency>
                         <code-name-base>org.netbeans.modules.j2ee.metadata.model.support</code-name-base>

--- a/spring.beans/test/unit/src/org/netbeans/modules/spring/api/beans/model/CommonAnnotationTestCase.java
+++ b/spring.beans/test/unit/src/org/netbeans/modules/spring/api/beans/model/CommonAnnotationTestCase.java
@@ -29,24 +29,17 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import org.netbeans.api.j2ee.core.Profile;
 
 import org.netbeans.api.java.classpath.ClassPath;
 import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ui.ProjectGroup;
 import org.netbeans.api.project.ui.ProjectGroupChangeListener;
 import org.netbeans.junit.MockServices;
-import org.netbeans.modules.j2ee.dd.api.web.WebAppMetadata;
 import org.netbeans.modules.j2ee.metadata.model.api.MetadataModel;
 import org.netbeans.modules.j2ee.metadata.model.api.MetadataModelAction;
 import org.netbeans.modules.j2ee.metadata.model.support.JavaSourceTestCase;
 import org.netbeans.modules.parsing.api.indexing.IndexingManager;
-import org.netbeans.modules.project.ui.OpenProjectList;
 import org.netbeans.modules.project.uiapi.OpenProjectsTrampoline;
-import org.netbeans.modules.web.api.webmodule.WebModule;
-import org.netbeans.modules.web.spi.webmodule.WebModuleFactory;
-import org.netbeans.modules.web.spi.webmodule.WebModuleImplementation2;
-import org.netbeans.modules.web.spi.webmodule.WebModuleProvider;
 import org.netbeans.spi.java.classpath.support.ClassPathSupport;
 import org.openide.filesystems.FileObject;
 import org.openide.util.test.MockLookup;
@@ -57,8 +50,6 @@ import org.openide.util.test.MockLookup;
  */
 public class CommonAnnotationTestCase extends JavaSourceTestCase {
 
-    WebModuleProvider webModuleProvider;
-
     public CommonAnnotationTestCase(String testName) {
         super(testName);
     }
@@ -66,9 +57,7 @@ public class CommonAnnotationTestCase extends JavaSourceTestCase {
     @Override
     protected void setUp() throws Exception {
         super.setUp();
-        webModuleProvider = new FakeWebModuleProvider(srcFO);
         MockLookup.setInstances(
-                webModuleProvider,
                 new ClassPathProviderImpl(),
                 new OpenProject());
         MockServices.setServices(
@@ -118,71 +107,6 @@ public class CommonAnnotationTestCase extends JavaSourceTestCase {
 
     //<editor-fold defaultstate="collapsed">
     
-    protected static class FakeWebModuleProvider implements WebModuleProvider {
-
-        private FileObject webRoot;
-
-        public FakeWebModuleProvider(FileObject webRoot) {
-            this.webRoot = webRoot;
-        }
-
-        @Override
-        public WebModule findWebModule(FileObject file) {
-            return WebModuleFactory.createWebModule(new FakeWebModuleImplementation2(webRoot));
-        }
-    }
-
-    private static class FakeWebModuleImplementation2 implements WebModuleImplementation2 {
-
-        private FileObject webRoot;
-
-        public FakeWebModuleImplementation2(FileObject webRoot) {
-            this.webRoot = webRoot;
-        }
-
-        @Override
-        public FileObject getDocumentBase() {
-            return webRoot;
-        }
-
-        @Override
-        public String getContextPath() {
-            return "/";
-        }
-
-        @Override
-        public Profile getJ2eeProfile() {
-            return Profile.JAVA_EE_6_FULL;
-        }
-
-        @Override
-        public FileObject getWebInf() {
-            return null;
-        }
-
-        @Override
-        public FileObject getDeploymentDescriptor() {
-            return null;
-        }
-
-        @Override
-        public FileObject[] getJavaSources() {
-            throw new UnsupportedOperationException("Not supported yet.");
-        }
-
-        @Override
-        public MetadataModel<WebAppMetadata> getMetadataModel() {
-            return null;
-        }
-
-        @Override
-        public void addPropertyChangeListener(PropertyChangeListener listener) {
-        }
-
-        @Override
-        public void removePropertyChangeListener(PropertyChangeListener listener) {
-        }
-    }
     
     public static class OpenProject implements  OpenProjectsTrampoline {
 

--- a/websvc.saas.api/nbproject/project.xml
+++ b/websvc.saas.api/nbproject/project.xml
@@ -215,12 +215,6 @@
                         <code-name-base>org.netbeans.modules.projectapi.nb</code-name-base>
                     </test-dependency>
                     <test-dependency>
-                        <code-name-base>org.netbeans.modules.websvc.saas.services.delicious</code-name-base>
-                    </test-dependency>
-                    <test-dependency>
-                        <code-name-base>org.netbeans.modules.websvc.saas.services.zillow</code-name-base>
-                    </test-dependency>
-                    <test-dependency>
                         <code-name-base>org.netbeans.modules.xml.retriever</code-name-base>
                     </test-dependency>
                     <test-dependency>

--- a/websvc.saas.codegen/nbproject/project.xml
+++ b/websvc.saas.codegen/nbproject/project.xml
@@ -260,12 +260,6 @@
                         <compile-dependency/>
                     </test-dependency>
                     <test-dependency>
-                        <code-name-base>org.netbeans.modules.websvc.saas.services.delicious</code-name-base>
-                    </test-dependency>
-                    <test-dependency>
-                        <code-name-base>org.netbeans.modules.websvc.saas.services.zillow</code-name-base>
-                    </test-dependency>
-                    <test-dependency>
                         <code-name-base>org.netbeans.modules.xml.retriever</code-name-base>
                     </test-dependency>
                     <test-dependency>


### PR DESCRIPTION
I've noticed that there are some modules with too wide test dependencies. Such modules cannot be compiled. I am adding the test compilation (not execution for now) into `.travis.yml` to make sure we always have compilable tests.

I'll fix the modules with non-compilable tests to compile.