### PR TITLE
[NETBEANS-54] Module Review libs.jvyamlb

### DIFF
--- a/libs.jvyamlb/external/binaries-list
+++ b/libs.jvyamlb/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-ED45F5C56EC70CC77936E92B43B6F32F46E6F4B3 jvyamlb-0.2.7.jar
+C8E994189BA694D5A07706C401D6FE8D8375A38A org.jruby.extras:jvyamlb:0.2.6

--- a/libs.jvyamlb/external/jvyamlb-0.2.6-license.txt
+++ b/libs.jvyamlb/external/jvyamlb-0.2.6-license.txt
@@ -1,0 +1,19 @@
+Copyright (c) 2008 Ola Bini <ola.bini@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of 
+this software and associated documentation files (the "Software"), to deal in 
+the Software without restriction, including without limitation the rights to 
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies 
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE 
+SOFTWARE.

--- a/libs.jvyamlb/nbproject/project.properties
+++ b/libs.jvyamlb/nbproject/project.properties
@@ -16,6 +16,6 @@
 # under the License.
 
 is.autoload=true
-release.external/jvyamlb-0.2.7.jar=modules/ext/jvyamlb-0.2.7.jar
+release.external/jvyamlb-0.2.6.jar=modules/ext/jvyamlb-0.2.6.jar
 
 sigtest.gen.fail.on.error=false

--- a/libs.jvyamlb/nbproject/project.xml
+++ b/libs.jvyamlb/nbproject/project.xml
@@ -58,8 +58,8 @@
                 <subpackages>org.jvyamlb</subpackages>
             </public-packages>
             <class-path-extension>
-                <runtime-relative-path>ext/jvyamlb-0.2.7.jar</runtime-relative-path>
-                <binary-origin>external/jvyamlb-0.2.7.jar</binary-origin>
+                <runtime-relative-path>ext/jvyamlb-0.2.6.jar</runtime-relative-path>
+                <binary-origin>external/jvyamlb-0.2.6.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>


### PR DESCRIPTION
  - Version 0.2.7 is not available in maven.central
  - Downgraded to 0.2.6 to see how it behaves in travis build
  - See issue #82 https://issues.apache.org/jira/browse/NETBEANS-82