### PR TITLE
[NETBEANS-54] Module Review o.eclipse.jgit

### DIFF
--- a/o.eclipse.jgit/external/binaries-list
+++ b/o.eclipse.jgit/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-B580E446B543A8DD2F5AA368B07F9C4C9C2E7029 org.eclipse.jgit-3.6.2.201501210735-r_nosignature.jar
+47D59DFFB5F02470CCFB6C1A5A31B6040A1636E5 org.eclipse.jgit:org.eclipse.jgit:3.6.2.201501210735-r

--- a/o.eclipse.jgit/nbproject/project.properties
+++ b/o.eclipse.jgit/nbproject/project.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-release.external/org.eclipse.jgit-3.6.2.201501210735-r_nosignature.jar=modules/org-eclipse-jgit.jar
+release.external/org.eclipse.jgit-3.6.2.201501210735-r.jar=modules/org-eclipse-jgit.jar
 is.autoload=true

--- a/o.eclipse.jgit/nbproject/project.xml
+++ b/o.eclipse.jgit/nbproject/project.xml
@@ -41,7 +41,7 @@
             <public-packages/>
             <class-path-extension>
                 <runtime-relative-path>org-eclipse-jgit.jar</runtime-relative-path>
-                <binary-origin>external/org.eclipse.jgit-3.6.2.201501210735-r_nosignature.jar</binary-origin>
+                <binary-origin>external/org.eclipse.jgit-3.6.2.201501210735-r.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>


### PR DESCRIPTION
Had to change from using a jar called:
org.eclipse.jgit-3.6.2.201501210735-r-nosignature.jar to
org.eclipse.jgit-3.6.2.201501210735-r.jar
Since the previous one wasnt in maven.  NO NOTICE file added - Not sure it needs one since its under EDL - see https://github.com/eclipse/jgit/tree/v3.6.2.201501210735-r