### PR TITLE
[NETBEANS-54] Module Review org.eclipse.jgit.java7

### DIFF
--- a/o.eclipse.jgit.java7/external/binaries-list
+++ b/o.eclipse.jgit.java7/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-244560B99152F3F9BC75DF2D6FAFA8A5216B06B6 org.eclipse.jgit.java7-3.6.2.201501210735-r_nosignature.jar
+D613D2ED86455CC8686A45B9B65215A9652E2943 org.eclipse.jgit:org.eclipse.jgit.java7:3.6.2.201501210735-r

--- a/o.eclipse.jgit.java7/nbproject/project.properties
+++ b/o.eclipse.jgit.java7/nbproject/project.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-release.external/org.eclipse.jgit.java7-3.6.2.201501210735-r_nosignature.jar=modules/org-eclipse-jgit-java7.jar
+release.external/org.eclipse.jgit.java7-3.6.2.201501210735-r.jar=modules/org-eclipse-jgit-java7.jar
 is.autoload=true

--- a/o.eclipse.jgit.java7/nbproject/project.xml
+++ b/o.eclipse.jgit.java7/nbproject/project.xml
@@ -28,7 +28,7 @@
             <public-packages/>
             <class-path-extension>
                 <runtime-relative-path>org-eclipse-jgit-java7.jar</runtime-relative-path>
-                <binary-origin>external/org.eclipse.jgit.java7-3.6.2.201501210735-r_nosignature.jar</binary-origin>
+                <binary-origin>external/org.eclipse.jgit.java7-3.6.2.201501210735-r.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>


### PR DESCRIPTION
Had to change from using a jar called:
org.eclipse.jgit.java7-3.6.2.201501210735-r-nosignature.jar to
org.eclipse.jgit.java7-3.6.2.201501210735-r.jar
Since the previous one wasn't in maven.  NO NOTICE file added - Not sure it needs one since its under EDL - see https://github.com/eclipse/jgit/tree/v3.6.2.201501210735-r