### PR TITLE
[NETBEANS-54] Module Review libs.cglib

### DIFF
--- a/libs.cglib/external/binaries-list
+++ b/libs.cglib/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-97D03461DC1C04FFC636DCB2579AAE7724A78EF2 cglib-2.2.jar
+97D03461DC1C04FFC636DCB2579AAE7724A78EF2 cglib:cglib:2.2

--- a/libs.cglib/external/cglib-2.2-notice.txt
+++ b/libs.cglib/external/cglib-2.2-notice.txt
@@ -1,0 +1,2 @@
+This product includes software developed by
+The Apache Software Foundation (http://www.apache.org/).


### PR DESCRIPTION
  - Updated maven coordinates for the external binary.
  - Added cglib-2.2 license from https://github.com/cglib/cglib
  - No other licensing issues found.