### PR TITLE
[NETBEANS-54] Module Review ide.kit

### DIFF
--- a/ide.kit/release/VERSION.txt
+++ b/ide.kit/release/VERSION.txt
@@ -1,43 +1,18 @@
-# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-
-# Copyright 2009-2017 Oracle and/or its affiliates. All rights reserved.
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
 #
-# Oracle and Java are registered trademarks of Oracle and/or its affiliates.
-# Other names may be trademarks of their respective owners.
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
-# The contents of this file are subject to the terms of either the GNU
-# General Public License Version 2 only ("GPL") or the Common
-# Development and Distribution License("CDDL") (collectively, the
-# "License"). You may not use this file except in compliance with the
-# License. You can obtain a copy of the License at
-# http://www.netbeans.org/cddl-gplv2.html
-# or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
-# specific language governing permissions and limitations under the
-# License.  When distributing the software, include this License Header
-# Notice in each file and include the License file at
-# nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
-# particular file as subject to the "Classpath" exception as provided
-# by Oracle in the GPL Version 2 section of the License file that
-# accompanied this code. If applicable, add the following below the
-# License Header, with the fields enclosed by brackets [] replaced by
-# your own identifying information:
-# "Portions Copyrighted [year] [name of copyright owner]"
-#
-# Contributor(s):
-#
-# The Original Software is NetBeans. The Initial Developer of the Original
-# Software is Sun Microsystems, Inc. Portions Copyright 2009-2010 Sun
-# Microsystems, Inc. All Rights Reserved.
-#
-# If you wish your version of this file to be governed by only the CDDL
-# or only the GPL Version 2, indicate your decision by adding
-# "[Contributor] elects to include this software in this distribution
-# under the [CDDL or GPL Version 2] license." If you do not indicate a
-# single choice of license, a recipient has the option to distribute
-# your version of this file under either the CDDL, the GPL Version 2 or
-# to extend the choice of license to its licensees as provided above.
-# However, if you add GPL Version 2 code and therefore, elected the GPL
-# Version 2 license, then the option applies only if the new code is
-# made subject to such option by the copyright holder.
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 # cluster incompatible release version
 22

--- a/ide.kit/test/qa-functional/data/BlacklistedClassesHandlerConfig.xml
+++ b/ide.kit/test/qa-functional/data/BlacklistedClassesHandlerConfig.xml
@@ -1,5 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
 
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <!--
     Document   : BlacklistedClassesHandlerConfig.xml
     Author     : mrkam@netbeans.og

--- a/ide.kit/test/qa-functional/data/SampleProject/nbproject/project.properties
+++ b/ide.kit/test/qa-functional/data/SampleProject/nbproject/project.properties
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 application.args=
 build.classes.dir=${build.dir}/classes
 build.classes.excludes=**/*.java,**/*.form

--- a/ide.kit/test/qa-functional/data/SampleProject/nbproject/project.xml
+++ b/ide.kit/test/qa-functional/data/SampleProject/nbproject/project.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <project xmlns="http://www.netbeans.org/ns/project/1">
     <type>org.netbeans.modules.java.j2seproject</type>
     <configuration>

--- a/ide.kit/test/qa-functional/data/kits.properties
+++ b/ide.kit/test/qa-functional/data/kits.properties
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 # --- BASE --- #
 org.netbeans.modules.mercurial=base
 org.netbeans.modules.ide.kit=base

--- a/nbbuild/build.xml
+++ b/nbbuild/build.xml
@@ -2049,6 +2049,7 @@ It is possible to use -Ddebug.port=3234 -Ddebug.pause=y to start the system in d
                 <exclude name="java.editor/test/qa-functional/data/**" /> <!--test data-->
                 <exclude name="java.editor/test/unit/data/**" /> <!--test data-->
                 <exclude name="java.editor.base/test/unit/data/**" /> <!--test data-->
+                <exclude name="ide.kit/test/qa-functional/**/*.txt" /> <!-- test data -->
             </fileset>
         </rat:report>
     </target>


### PR DESCRIPTION
  - No external binaries.
  - Added Apache license to different xml/properties files and release/VERSION.txt.
  - Added rat exclusion list for all qa-functional/**/*.txt files.
  - Remaining files to be handled centrally.
  - No other licensing issues found.