### PR TITLE
[NETBEANS-54] Module Review spi.debugger.ui

### DIFF
--- a/spi.debugger.ui/l10n.list
+++ b/spi.debugger.ui/l10n.list
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 # apisupport/samples
 read global
 ${l10n-module}/src/**/*.gif

--- a/spi.debugger.ui/src/META-INF/debugger/BreakpointsView/org.netbeans.spi.viewmodel.ColumnModel
+++ b/spi.debugger.ui/src/META-INF/debugger/BreakpointsView/org.netbeans.spi.viewmodel.ColumnModel
@@ -1,42 +1,18 @@
-# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
-# Copyright 2009-2017 Oracle and/or its affiliates. All rights reserved.
-#
-# Oracle and Java are registered trademarks of Oracle and/or its affiliates.
-# Other names may be trademarks of their respective owners.
-#
-# The contents of this file are subject to the terms of either the GNU
-# General Public License Version 2 only ("GPL") or the Common
-# Development and Distribution License("CDDL") (collectively, the
-# "License"). You may not use this file except in compliance with the
-# License. You can obtain a copy of the License at
-# http://www.netbeans.org/cddl-gplv2.html
-# or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
-# specific language governing permissions and limitations under the
-# License.  When distributing the software, include this License Header
-# Notice in each file and include the License file at
-# nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
-# particular file as subject to the "Classpath" exception as provided
-# by Oracle in the GPL Version 2 section of the License file that
-# accompanied this code. If applicable, add the following below the
-# License Header, with the fields enclosed by brackets [] replaced by
-# your own identifying information:
-# "Portions Copyrighted [year] [name of copyright owner]"
-#
-# Contributor(s):
-#
-# The Original Software is NetBeans. The Initial Developer of the Original
-# Software is Sun Microsystems, Inc. Portions Copyright 2009-2010 Sun
-# Microsystems, Inc. All Rights Reserved.
-#
-# If you wish your version of this file to be governed by only the CDDL
-# or only the GPL Version 2, indicate your decision by adding
-# "[Contributor] elects to include this software in this distribution
-# under the [CDDL or GPL Version 2] license." If you do not indicate a
-# single choice of license, a recipient has the option to distribute
-# your version of this file under either the CDDL, the GPL Version 2 or
-# to extend the choice of license to its licensees as provided above.
-# However, if you add GPL Version 2 code and therefore, elected the GPL
-# Version 2 license, then the option applies only if the new code is
-# made subject to such option by the copyright holder.
 org.netbeans.modules.debugger.ui.models.ColumnModels.createDefaultBreakpointsColumn()

--- a/spi.debugger.ui/src/META-INF/debugger/BreakpointsView/org.netbeans.spi.viewmodel.NodeActionsProvider
+++ b/spi.debugger.ui/src/META-INF/debugger/BreakpointsView/org.netbeans.spi.viewmodel.NodeActionsProvider
@@ -1,42 +1,18 @@
-# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
-# Copyright 2009-2017 Oracle and/or its affiliates. All rights reserved.
-#
-# Oracle and Java are registered trademarks of Oracle and/or its affiliates.
-# Other names may be trademarks of their respective owners.
-#
-# The contents of this file are subject to the terms of either the GNU
-# General Public License Version 2 only ("GPL") or the Common
-# Development and Distribution License("CDDL") (collectively, the
-# "License"). You may not use this file except in compliance with the
-# License. You can obtain a copy of the License at
-# http://www.netbeans.org/cddl-gplv2.html
-# or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
-# specific language governing permissions and limitations under the
-# License.  When distributing the software, include this License Header
-# Notice in each file and include the License file at
-# nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
-# particular file as subject to the "Classpath" exception as provided
-# by Oracle in the GPL Version 2 section of the License file that
-# accompanied this code. If applicable, add the following below the
-# License Header, with the fields enclosed by brackets [] replaced by
-# your own identifying information:
-# "Portions Copyrighted [year] [name of copyright owner]"
-#
-# Contributor(s):
-#
-# The Original Software is NetBeans. The Initial Developer of the Original
-# Software is Sun Microsystems, Inc. Portions Copyright 2009-2010 Sun
-# Microsystems, Inc. All Rights Reserved.
-#
-# If you wish your version of this file to be governed by only the CDDL
-# or only the GPL Version 2, indicate your decision by adding
-# "[Contributor] elects to include this software in this distribution
-# under the [CDDL or GPL Version 2] license." If you do not indicate a
-# single choice of license, a recipient has the option to distribute
-# your version of this file under either the CDDL, the GPL Version 2 or
-# to extend the choice of license to its licensees as provided above.
-# However, if you add GPL Version 2 code and therefore, elected the GPL
-# Version 2 license, then the option applies only if the new code is
-# made subject to such option by the copyright holder.
 org.netbeans.modules.debugger.ui.models.BreakpointsActionsProvider

--- a/spi.debugger.ui/src/META-INF/debugger/BreakpointsView/org.netbeans.spi.viewmodel.NodeModel
+++ b/spi.debugger.ui/src/META-INF/debugger/BreakpointsView/org.netbeans.spi.viewmodel.NodeModel
@@ -1,42 +1,18 @@
-# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
-# Copyright 2009-2017 Oracle and/or its affiliates. All rights reserved.
-#
-# Oracle and Java are registered trademarks of Oracle and/or its affiliates.
-# Other names may be trademarks of their respective owners.
-#
-# The contents of this file are subject to the terms of either the GNU
-# General Public License Version 2 only ("GPL") or the Common
-# Development and Distribution License("CDDL") (collectively, the
-# "License"). You may not use this file except in compliance with the
-# License. You can obtain a copy of the License at
-# http://www.netbeans.org/cddl-gplv2.html
-# or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
-# specific language governing permissions and limitations under the
-# License.  When distributing the software, include this License Header
-# Notice in each file and include the License file at
-# nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
-# particular file as subject to the "Classpath" exception as provided
-# by Oracle in the GPL Version 2 section of the License file that
-# accompanied this code. If applicable, add the following below the
-# License Header, with the fields enclosed by brackets [] replaced by
-# your own identifying information:
-# "Portions Copyrighted [year] [name of copyright owner]"
-#
-# Contributor(s):
-#
-# The Original Software is NetBeans. The Initial Developer of the Original
-# Software is Sun Microsystems, Inc. Portions Copyright 2009-2010 Sun
-# Microsystems, Inc. All Rights Reserved.
-#
-# If you wish your version of this file to be governed by only the CDDL
-# or only the GPL Version 2, indicate your decision by adding
-# "[Contributor] elects to include this software in this distribution
-# under the [CDDL or GPL Version 2] license." If you do not indicate a
-# single choice of license, a recipient has the option to distribute
-# your version of this file under either the CDDL, the GPL Version 2 or
-# to extend the choice of license to its licensees as provided above.
-# However, if you add GPL Version 2 code and therefore, elected the GPL
-# Version 2 license, then the option applies only if the new code is
-# made subject to such option by the copyright holder.
 org.netbeans.modules.debugger.ui.models.BreakpointsNodeModel

--- a/spi.debugger.ui/src/META-INF/debugger/BreakpointsView/org.netbeans.spi.viewmodel.TreeExpansionModelFilter
+++ b/spi.debugger.ui/src/META-INF/debugger/BreakpointsView/org.netbeans.spi.viewmodel.TreeExpansionModelFilter
@@ -1,42 +1,18 @@
-# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
-# Copyright 2009-2017 Oracle and/or its affiliates. All rights reserved.
-#
-# Oracle and Java are registered trademarks of Oracle and/or its affiliates.
-# Other names may be trademarks of their respective owners.
-#
-# The contents of this file are subject to the terms of either the GNU
-# General Public License Version 2 only ("GPL") or the Common
-# Development and Distribution License("CDDL") (collectively, the
-# "License"). You may not use this file except in compliance with the
-# License. You can obtain a copy of the License at
-# http://www.netbeans.org/cddl-gplv2.html
-# or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
-# specific language governing permissions and limitations under the
-# License.  When distributing the software, include this License Header
-# Notice in each file and include the License file at
-# nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
-# particular file as subject to the "Classpath" exception as provided
-# by Oracle in the GPL Version 2 section of the License file that
-# accompanied this code. If applicable, add the following below the
-# License Header, with the fields enclosed by brackets [] replaced by
-# your own identifying information:
-# "Portions Copyrighted [year] [name of copyright owner]"
-#
-# Contributor(s):
-#
-# The Original Software is NetBeans. The Initial Developer of the Original
-# Software is Sun Microsystems, Inc. Portions Copyright 2009-2010 Sun
-# Microsystems, Inc. All Rights Reserved.
-#
-# If you wish your version of this file to be governed by only the CDDL
-# or only the GPL Version 2, indicate your decision by adding
-# "[Contributor] elects to include this software in this distribution
-# under the [CDDL or GPL Version 2] license." If you do not indicate a
-# single choice of license, a recipient has the option to distribute
-# your version of this file under either the CDDL, the GPL Version 2 or
-# to extend the choice of license to its licensees as provided above.
-# However, if you add GPL Version 2 code and therefore, elected the GPL
-# Version 2 license, then the option applies only if the new code is
-# made subject to such option by the copyright holder.
 org.netbeans.modules.debugger.ui.models.BreakpointsGroupExpansionFilter

--- a/spi.debugger.ui/src/META-INF/debugger/BreakpointsView/org.netbeans.spi.viewmodel.TreeModel
+++ b/spi.debugger.ui/src/META-INF/debugger/BreakpointsView/org.netbeans.spi.viewmodel.TreeModel
@@ -1,42 +1,18 @@
-# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
-# Copyright 2009-2017 Oracle and/or its affiliates. All rights reserved.
-#
-# Oracle and Java are registered trademarks of Oracle and/or its affiliates.
-# Other names may be trademarks of their respective owners.
-#
-# The contents of this file are subject to the terms of either the GNU
-# General Public License Version 2 only ("GPL") or the Common
-# Development and Distribution License("CDDL") (collectively, the
-# "License"). You may not use this file except in compliance with the
-# License. You can obtain a copy of the License at
-# http://www.netbeans.org/cddl-gplv2.html
-# or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
-# specific language governing permissions and limitations under the
-# License.  When distributing the software, include this License Header
-# Notice in each file and include the License file at
-# nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
-# particular file as subject to the "Classpath" exception as provided
-# by Oracle in the GPL Version 2 section of the License file that
-# accompanied this code. If applicable, add the following below the
-# License Header, with the fields enclosed by brackets [] replaced by
-# your own identifying information:
-# "Portions Copyrighted [year] [name of copyright owner]"
-#
-# Contributor(s):
-#
-# The Original Software is NetBeans. The Initial Developer of the Original
-# Software is Sun Microsystems, Inc. Portions Copyright 2009-2010 Sun
-# Microsystems, Inc. All Rights Reserved.
-#
-# If you wish your version of this file to be governed by only the CDDL
-# or only the GPL Version 2, indicate your decision by adding
-# "[Contributor] elects to include this software in this distribution
-# under the [CDDL or GPL Version 2] license." If you do not indicate a
-# single choice of license, a recipient has the option to distribute
-# your version of this file under either the CDDL, the GPL Version 2 or
-# to extend the choice of license to its licensees as provided above.
-# However, if you add GPL Version 2 code and therefore, elected the GPL
-# Version 2 license, then the option applies only if the new code is
-# made subject to such option by the copyright holder.
 org.netbeans.modules.debugger.ui.models.BreakpointsTreeModel

--- a/spi.debugger.ui/src/META-INF/debugger/CallStackView/org.netbeans.spi.viewmodel.ColumnModel
+++ b/spi.debugger.ui/src/META-INF/debugger/CallStackView/org.netbeans.spi.viewmodel.ColumnModel
@@ -1,43 +1,19 @@
-# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
-# Copyright 2009-2017 Oracle and/or its affiliates. All rights reserved.
-#
-# Oracle and Java are registered trademarks of Oracle and/or its affiliates.
-# Other names may be trademarks of their respective owners.
-#
-# The contents of this file are subject to the terms of either the GNU
-# General Public License Version 2 only ("GPL") or the Common
-# Development and Distribution License("CDDL") (collectively, the
-# "License"). You may not use this file except in compliance with the
-# License. You can obtain a copy of the License at
-# http://www.netbeans.org/cddl-gplv2.html
-# or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
-# specific language governing permissions and limitations under the
-# License.  When distributing the software, include this License Header
-# Notice in each file and include the License file at
-# nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
-# particular file as subject to the "Classpath" exception as provided
-# by Oracle in the GPL Version 2 section of the License file that
-# accompanied this code. If applicable, add the following below the
-# License Header, with the fields enclosed by brackets [] replaced by
-# your own identifying information:
-# "Portions Copyrighted [year] [name of copyright owner]"
-#
-# Contributor(s):
-#
-# The Original Software is NetBeans. The Initial Developer of the Original
-# Software is Sun Microsystems, Inc. Portions Copyright 2009-2010 Sun
-# Microsystems, Inc. All Rights Reserved.
-#
-# If you wish your version of this file to be governed by only the CDDL
-# or only the GPL Version 2, indicate your decision by adding
-# "[Contributor] elects to include this software in this distribution
-# under the [CDDL or GPL Version 2] license." If you do not indicate a
-# single choice of license, a recipient has the option to distribute
-# your version of this file under either the CDDL, the GPL Version 2 or
-# to extend the choice of license to its licensees as provided above.
-# However, if you add GPL Version 2 code and therefore, elected the GPL
-# Version 2 license, then the option applies only if the new code is
-# made subject to such option by the copyright holder.
 org.netbeans.modules.debugger.ui.models.ColumnModels.createCallStackLocationColumn()
 org.netbeans.modules.debugger.ui.models.ColumnModels.createDefaultCallStackColumn()

--- a/spi.debugger.ui/src/META-INF/debugger/LocalsView/org.netbeans.spi.viewmodel.ColumnModel
+++ b/spi.debugger.ui/src/META-INF/debugger/LocalsView/org.netbeans.spi.viewmodel.ColumnModel
@@ -1,44 +1,20 @@
-# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
-# Copyright 2009-2017 Oracle and/or its affiliates. All rights reserved.
-#
-# Oracle and Java are registered trademarks of Oracle and/or its affiliates.
-# Other names may be trademarks of their respective owners.
-#
-# The contents of this file are subject to the terms of either the GNU
-# General Public License Version 2 only ("GPL") or the Common
-# Development and Distribution License("CDDL") (collectively, the
-# "License"). You may not use this file except in compliance with the
-# License. You can obtain a copy of the License at
-# http://www.netbeans.org/cddl-gplv2.html
-# or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
-# specific language governing permissions and limitations under the
-# License.  When distributing the software, include this License Header
-# Notice in each file and include the License file at
-# nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
-# particular file as subject to the "Classpath" exception as provided
-# by Oracle in the GPL Version 2 section of the License file that
-# accompanied this code. If applicable, add the following below the
-# License Header, with the fields enclosed by brackets [] replaced by
-# your own identifying information:
-# "Portions Copyrighted [year] [name of copyright owner]"
-#
-# Contributor(s):
-#
-# The Original Software is NetBeans. The Initial Developer of the Original
-# Software is Sun Microsystems, Inc. Portions Copyright 2009-2010 Sun
-# Microsystems, Inc. All Rights Reserved.
-#
-# If you wish your version of this file to be governed by only the CDDL
-# or only the GPL Version 2, indicate your decision by adding
-# "[Contributor] elects to include this software in this distribution
-# under the [CDDL or GPL Version 2] license." If you do not indicate a
-# single choice of license, a recipient has the option to distribute
-# your version of this file under either the CDDL, the GPL Version 2 or
-# to extend the choice of license to its licensees as provided above.
-# However, if you add GPL Version 2 code and therefore, elected the GPL
-# Version 2 license, then the option applies only if the new code is
-# made subject to such option by the copyright holder.
 org.netbeans.modules.debugger.ui.models.ColumnModels.createLocalsTypeColumn()
 org.netbeans.modules.debugger.ui.models.ColumnModels.createLocalsValueColumn()
 org.netbeans.modules.debugger.ui.models.ColumnModels.createLocalsToStringColumn()

--- a/spi.debugger.ui/src/META-INF/debugger/LocalsView/org.netbeans.spi.viewmodel.NodeActionsProvider
+++ b/spi.debugger.ui/src/META-INF/debugger/LocalsView/org.netbeans.spi.viewmodel.NodeActionsProvider
@@ -1,42 +1,18 @@
-# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
-# Copyright 2009-2017 Oracle and/or its affiliates. All rights reserved.
-#
-# Oracle and Java are registered trademarks of Oracle and/or its affiliates.
-# Other names may be trademarks of their respective owners.
-#
-# The contents of this file are subject to the terms of either the GNU
-# General Public License Version 2 only ("GPL") or the Common
-# Development and Distribution License("CDDL") (collectively, the
-# "License"). You may not use this file except in compliance with the
-# License. You can obtain a copy of the License at
-# http://www.netbeans.org/cddl-gplv2.html
-# or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
-# specific language governing permissions and limitations under the
-# License.  When distributing the software, include this License Header
-# Notice in each file and include the License file at
-# nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
-# particular file as subject to the "Classpath" exception as provided
-# by Oracle in the GPL Version 2 section of the License file that
-# accompanied this code. If applicable, add the following below the
-# License Header, with the fields enclosed by brackets [] replaced by
-# your own identifying information:
-# "Portions Copyrighted [year] [name of copyright owner]"
-#
-# Contributor(s):
-#
-# The Original Software is NetBeans. The Initial Developer of the Original
-# Software is Sun Microsystems, Inc. Portions Copyright 2009-2010 Sun
-# Microsystems, Inc. All Rights Reserved.
-#
-# If you wish your version of this file to be governed by only the CDDL
-# or only the GPL Version 2, indicate your decision by adding
-# "[Contributor] elects to include this software in this distribution
-# under the [CDDL or GPL Version 2] license." If you do not indicate a
-# single choice of license, a recipient has the option to distribute
-# your version of this file under either the CDDL, the GPL Version 2 or
-# to extend the choice of license to its licensees as provided above.
-# However, if you add GPL Version 2 code and therefore, elected the GPL
-# Version 2 license, then the option applies only if the new code is
-# made subject to such option by the copyright holder.
 org.netbeans.modules.debugger.ui.models.VariablesActionsProvider

--- a/spi.debugger.ui/src/META-INF/debugger/ResultsView/org.netbeans.spi.viewmodel.ColumnModel
+++ b/spi.debugger.ui/src/META-INF/debugger/ResultsView/org.netbeans.spi.viewmodel.ColumnModel
@@ -1,44 +1,20 @@
-# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
-# Copyright 2009-2017 Oracle and/or its affiliates. All rights reserved.
-#
-# Oracle and Java are registered trademarks of Oracle and/or its affiliates.
-# Other names may be trademarks of their respective owners.
-#
-# The contents of this file are subject to the terms of either the GNU
-# General Public License Version 2 only ("GPL") or the Common
-# Development and Distribution License("CDDL") (collectively, the
-# "License"). You may not use this file except in compliance with the
-# License. You can obtain a copy of the License at
-# http://www.netbeans.org/cddl-gplv2.html
-# or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
-# specific language governing permissions and limitations under the
-# License.  When distributing the software, include this License Header
-# Notice in each file and include the License file at
-# nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
-# particular file as subject to the "Classpath" exception as provided
-# by Oracle in the GPL Version 2 section of the License file that
-# accompanied this code. If applicable, add the following below the
-# License Header, with the fields enclosed by brackets [] replaced by
-# your own identifying information:
-# "Portions Copyrighted [year] [name of copyright owner]"
-#
-# Contributor(s):
-#
-# The Original Software is NetBeans. The Initial Developer of the Original
-# Software is Sun Microsystems, Inc. Portions Copyright 2009-2010 Sun
-# Microsystems, Inc. All Rights Reserved.
-#
-# If you wish your version of this file to be governed by only the CDDL
-# or only the GPL Version 2, indicate your decision by adding
-# "[Contributor] elects to include this software in this distribution
-# under the [CDDL or GPL Version 2] license." If you do not indicate a
-# single choice of license, a recipient has the option to distribute
-# your version of this file under either the CDDL, the GPL Version 2 or
-# to extend the choice of license to its licensees as provided above.
-# However, if you add GPL Version 2 code and therefore, elected the GPL
-# Version 2 license, then the option applies only if the new code is
-# made subject to such option by the copyright holder.
 org.netbeans.modules.debugger.ui.models.ColumnModels.createLocalsTypeColumn()
 org.netbeans.modules.debugger.ui.models.ColumnModels.createLocalsValueColumn()
 org.netbeans.modules.debugger.ui.models.ColumnModels.createLocalsToStringColumn()

--- a/spi.debugger.ui/src/META-INF/debugger/SessionsView/org.netbeans.spi.viewmodel.ColumnModel
+++ b/spi.debugger.ui/src/META-INF/debugger/SessionsView/org.netbeans.spi.viewmodel.ColumnModel
@@ -1,44 +1,20 @@
-# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
-# Copyright 2009-2017 Oracle and/or its affiliates. All rights reserved.
-#
-# Oracle and Java are registered trademarks of Oracle and/or its affiliates.
-# Other names may be trademarks of their respective owners.
-#
-# The contents of this file are subject to the terms of either the GNU
-# General Public License Version 2 only ("GPL") or the Common
-# Development and Distribution License("CDDL") (collectively, the
-# "License"). You may not use this file except in compliance with the
-# License. You can obtain a copy of the License at
-# http://www.netbeans.org/cddl-gplv2.html
-# or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
-# specific language governing permissions and limitations under the
-# License.  When distributing the software, include this License Header
-# Notice in each file and include the License file at
-# nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
-# particular file as subject to the "Classpath" exception as provided
-# by Oracle in the GPL Version 2 section of the License file that
-# accompanied this code. If applicable, add the following below the
-# License Header, with the fields enclosed by brackets [] replaced by
-# your own identifying information:
-# "Portions Copyrighted [year] [name of copyright owner]"
-#
-# Contributor(s):
-#
-# The Original Software is NetBeans. The Initial Developer of the Original
-# Software is Sun Microsystems, Inc. Portions Copyright 2009-2010 Sun
-# Microsystems, Inc. All Rights Reserved.
-#
-# If you wish your version of this file to be governed by only the CDDL
-# or only the GPL Version 2, indicate your decision by adding
-# "[Contributor] elects to include this software in this distribution
-# under the [CDDL or GPL Version 2] license." If you do not indicate a
-# single choice of license, a recipient has the option to distribute
-# your version of this file under either the CDDL, the GPL Version 2 or
-# to extend the choice of license to its licensees as provided above.
-# However, if you add GPL Version 2 code and therefore, elected the GPL
-# Version 2 license, then the option applies only if the new code is
-# made subject to such option by the copyright holder.
 org.netbeans.modules.debugger.ui.models.ColumnModels.createSessionStateColumn()
 org.netbeans.modules.debugger.ui.models.ColumnModels.createSessionLanguageColumn()
 org.netbeans.modules.debugger.ui.models.ColumnModels.createSessionHostNameColumn()

--- a/spi.debugger.ui/src/META-INF/debugger/SessionsView/org.netbeans.spi.viewmodel.NodeActionsProvider
+++ b/spi.debugger.ui/src/META-INF/debugger/SessionsView/org.netbeans.spi.viewmodel.NodeActionsProvider
@@ -1,42 +1,18 @@
-# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
-# Copyright 2009-2017 Oracle and/or its affiliates. All rights reserved.
-#
-# Oracle and Java are registered trademarks of Oracle and/or its affiliates.
-# Other names may be trademarks of their respective owners.
-#
-# The contents of this file are subject to the terms of either the GNU
-# General Public License Version 2 only ("GPL") or the Common
-# Development and Distribution License("CDDL") (collectively, the
-# "License"). You may not use this file except in compliance with the
-# License. You can obtain a copy of the License at
-# http://www.netbeans.org/cddl-gplv2.html
-# or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
-# specific language governing permissions and limitations under the
-# License.  When distributing the software, include this License Header
-# Notice in each file and include the License file at
-# nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
-# particular file as subject to the "Classpath" exception as provided
-# by Oracle in the GPL Version 2 section of the License file that
-# accompanied this code. If applicable, add the following below the
-# License Header, with the fields enclosed by brackets [] replaced by
-# your own identifying information:
-# "Portions Copyrighted [year] [name of copyright owner]"
-#
-# Contributor(s):
-#
-# The Original Software is NetBeans. The Initial Developer of the Original
-# Software is Sun Microsystems, Inc. Portions Copyright 2009-2010 Sun
-# Microsystems, Inc. All Rights Reserved.
-#
-# If you wish your version of this file to be governed by only the CDDL
-# or only the GPL Version 2, indicate your decision by adding
-# "[Contributor] elects to include this software in this distribution
-# under the [CDDL or GPL Version 2] license." If you do not indicate a
-# single choice of license, a recipient has the option to distribute
-# your version of this file under either the CDDL, the GPL Version 2 or
-# to extend the choice of license to its licensees as provided above.
-# However, if you add GPL Version 2 code and therefore, elected the GPL
-# Version 2 license, then the option applies only if the new code is
-# made subject to such option by the copyright holder.
 org.netbeans.modules.debugger.ui.models.SessionsActionsProvider

--- a/spi.debugger.ui/src/META-INF/debugger/SessionsView/org.netbeans.spi.viewmodel.NodeModel
+++ b/spi.debugger.ui/src/META-INF/debugger/SessionsView/org.netbeans.spi.viewmodel.NodeModel
@@ -1,42 +1,18 @@
-# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
-# Copyright 2009-2017 Oracle and/or its affiliates. All rights reserved.
-#
-# Oracle and Java are registered trademarks of Oracle and/or its affiliates.
-# Other names may be trademarks of their respective owners.
-#
-# The contents of this file are subject to the terms of either the GNU
-# General Public License Version 2 only ("GPL") or the Common
-# Development and Distribution License("CDDL") (collectively, the
-# "License"). You may not use this file except in compliance with the
-# License. You can obtain a copy of the License at
-# http://www.netbeans.org/cddl-gplv2.html
-# or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
-# specific language governing permissions and limitations under the
-# License.  When distributing the software, include this License Header
-# Notice in each file and include the License file at
-# nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
-# particular file as subject to the "Classpath" exception as provided
-# by Oracle in the GPL Version 2 section of the License file that
-# accompanied this code. If applicable, add the following below the
-# License Header, with the fields enclosed by brackets [] replaced by
-# your own identifying information:
-# "Portions Copyrighted [year] [name of copyright owner]"
-#
-# Contributor(s):
-#
-# The Original Software is NetBeans. The Initial Developer of the Original
-# Software is Sun Microsystems, Inc. Portions Copyright 2009-2010 Sun
-# Microsystems, Inc. All Rights Reserved.
-#
-# If you wish your version of this file to be governed by only the CDDL
-# or only the GPL Version 2, indicate your decision by adding
-# "[Contributor] elects to include this software in this distribution
-# under the [CDDL or GPL Version 2] license." If you do not indicate a
-# single choice of license, a recipient has the option to distribute
-# your version of this file under either the CDDL, the GPL Version 2 or
-# to extend the choice of license to its licensees as provided above.
-# However, if you add GPL Version 2 code and therefore, elected the GPL
-# Version 2 license, then the option applies only if the new code is
-# made subject to such option by the copyright holder.
 org.netbeans.modules.debugger.ui.models.SesionsNodeModel

--- a/spi.debugger.ui/src/META-INF/debugger/SessionsView/org.netbeans.spi.viewmodel.TableModel
+++ b/spi.debugger.ui/src/META-INF/debugger/SessionsView/org.netbeans.spi.viewmodel.TableModel
@@ -1,42 +1,18 @@
-# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
-# Copyright 2009-2017 Oracle and/or its affiliates. All rights reserved.
-#
-# Oracle and Java are registered trademarks of Oracle and/or its affiliates.
-# Other names may be trademarks of their respective owners.
-#
-# The contents of this file are subject to the terms of either the GNU
-# General Public License Version 2 only ("GPL") or the Common
-# Development and Distribution License("CDDL") (collectively, the
-# "License"). You may not use this file except in compliance with the
-# License. You can obtain a copy of the License at
-# http://www.netbeans.org/cddl-gplv2.html
-# or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
-# specific language governing permissions and limitations under the
-# License.  When distributing the software, include this License Header
-# Notice in each file and include the License file at
-# nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
-# particular file as subject to the "Classpath" exception as provided
-# by Oracle in the GPL Version 2 section of the License file that
-# accompanied this code. If applicable, add the following below the
-# License Header, with the fields enclosed by brackets [] replaced by
-# your own identifying information:
-# "Portions Copyrighted [year] [name of copyright owner]"
-#
-# Contributor(s):
-#
-# The Original Software is NetBeans. The Initial Developer of the Original
-# Software is Sun Microsystems, Inc. Portions Copyright 2009-2010 Sun
-# Microsystems, Inc. All Rights Reserved.
-#
-# If you wish your version of this file to be governed by only the CDDL
-# or only the GPL Version 2, indicate your decision by adding
-# "[Contributor] elects to include this software in this distribution
-# under the [CDDL or GPL Version 2] license." If you do not indicate a
-# single choice of license, a recipient has the option to distribute
-# your version of this file under either the CDDL, the GPL Version 2 or
-# to extend the choice of license to its licensees as provided above.
-# However, if you add GPL Version 2 code and therefore, elected the GPL
-# Version 2 license, then the option applies only if the new code is
-# made subject to such option by the copyright holder.
 org.netbeans.modules.debugger.ui.models.SessionsTableModel

--- a/spi.debugger.ui/src/META-INF/debugger/SessionsView/org.netbeans.spi.viewmodel.TreeModel
+++ b/spi.debugger.ui/src/META-INF/debugger/SessionsView/org.netbeans.spi.viewmodel.TreeModel
@@ -1,42 +1,18 @@
-# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
-# Copyright 2009-2017 Oracle and/or its affiliates. All rights reserved.
-#
-# Oracle and Java are registered trademarks of Oracle and/or its affiliates.
-# Other names may be trademarks of their respective owners.
-#
-# The contents of this file are subject to the terms of either the GNU
-# General Public License Version 2 only ("GPL") or the Common
-# Development and Distribution License("CDDL") (collectively, the
-# "License"). You may not use this file except in compliance with the
-# License. You can obtain a copy of the License at
-# http://www.netbeans.org/cddl-gplv2.html
-# or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
-# specific language governing permissions and limitations under the
-# License.  When distributing the software, include this License Header
-# Notice in each file and include the License file at
-# nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
-# particular file as subject to the "Classpath" exception as provided
-# by Oracle in the GPL Version 2 section of the License file that
-# accompanied this code. If applicable, add the following below the
-# License Header, with the fields enclosed by brackets [] replaced by
-# your own identifying information:
-# "Portions Copyrighted [year] [name of copyright owner]"
-#
-# Contributor(s):
-#
-# The Original Software is NetBeans. The Initial Developer of the Original
-# Software is Sun Microsystems, Inc. Portions Copyright 2009-2010 Sun
-# Microsystems, Inc. All Rights Reserved.
-#
-# If you wish your version of this file to be governed by only the CDDL
-# or only the GPL Version 2, indicate your decision by adding
-# "[Contributor] elects to include this software in this distribution
-# under the [CDDL or GPL Version 2] license." If you do not indicate a
-# single choice of license, a recipient has the option to distribute
-# your version of this file under either the CDDL, the GPL Version 2 or
-# to extend the choice of license to its licensees as provided above.
-# However, if you add GPL Version 2 code and therefore, elected the GPL
-# Version 2 license, then the option applies only if the new code is
-# made subject to such option by the copyright holder.
 org.netbeans.modules.debugger.ui.models.SessionsTreeModel

--- a/spi.debugger.ui/src/META-INF/debugger/ThreadsView/org.netbeans.spi.viewmodel.ColumnModel
+++ b/spi.debugger.ui/src/META-INF/debugger/ThreadsView/org.netbeans.spi.viewmodel.ColumnModel
@@ -1,44 +1,20 @@
-# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
-# Copyright 2009-2017 Oracle and/or its affiliates. All rights reserved.
-#
-# Oracle and Java are registered trademarks of Oracle and/or its affiliates.
-# Other names may be trademarks of their respective owners.
-#
-# The contents of this file are subject to the terms of either the GNU
-# General Public License Version 2 only ("GPL") or the Common
-# Development and Distribution License("CDDL") (collectively, the
-# "License"). You may not use this file except in compliance with the
-# License. You can obtain a copy of the License at
-# http://www.netbeans.org/cddl-gplv2.html
-# or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
-# specific language governing permissions and limitations under the
-# License.  When distributing the software, include this License Header
-# Notice in each file and include the License file at
-# nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
-# particular file as subject to the "Classpath" exception as provided
-# by Oracle in the GPL Version 2 section of the License file that
-# accompanied this code. If applicable, add the following below the
-# License Header, with the fields enclosed by brackets [] replaced by
-# your own identifying information:
-# "Portions Copyrighted [year] [name of copyright owner]"
-#
-# Contributor(s):
-#
-# The Original Software is NetBeans. The Initial Developer of the Original
-# Software is Sun Microsystems, Inc. Portions Copyright 2009-2010 Sun
-# Microsystems, Inc. All Rights Reserved.
-#
-# If you wish your version of this file to be governed by only the CDDL
-# or only the GPL Version 2, indicate your decision by adding
-# "[Contributor] elects to include this software in this distribution
-# under the [CDDL or GPL Version 2] license." If you do not indicate a
-# single choice of license, a recipient has the option to distribute
-# your version of this file under either the CDDL, the GPL Version 2 or
-# to extend the choice of license to its licensees as provided above.
-# However, if you add GPL Version 2 code and therefore, elected the GPL
-# Version 2 license, then the option applies only if the new code is
-# made subject to such option by the copyright holder.
 org.netbeans.modules.debugger.ui.models.ColumnModels.createThreadStateColumn()
 org.netbeans.modules.debugger.ui.models.ColumnModels.createThreadSuspendedColumn()
 org.netbeans.modules.debugger.ui.models.ColumnModels.createDefaultThreadColumn()

--- a/spi.debugger.ui/src/META-INF/debugger/WatchesView/org.netbeans.spi.viewmodel.ColumnModel
+++ b/spi.debugger.ui/src/META-INF/debugger/WatchesView/org.netbeans.spi.viewmodel.ColumnModel
@@ -1,44 +1,20 @@
-# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
-# Copyright 2009-2017 Oracle and/or its affiliates. All rights reserved.
-#
-# Oracle and Java are registered trademarks of Oracle and/or its affiliates.
-# Other names may be trademarks of their respective owners.
-#
-# The contents of this file are subject to the terms of either the GNU
-# General Public License Version 2 only ("GPL") or the Common
-# Development and Distribution License("CDDL") (collectively, the
-# "License"). You may not use this file except in compliance with the
-# License. You can obtain a copy of the License at
-# http://www.netbeans.org/cddl-gplv2.html
-# or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
-# specific language governing permissions and limitations under the
-# License.  When distributing the software, include this License Header
-# Notice in each file and include the License file at
-# nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
-# particular file as subject to the "Classpath" exception as provided
-# by Oracle in the GPL Version 2 section of the License file that
-# accompanied this code. If applicable, add the following below the
-# License Header, with the fields enclosed by brackets [] replaced by
-# your own identifying information:
-# "Portions Copyrighted [year] [name of copyright owner]"
-#
-# Contributor(s):
-#
-# The Original Software is NetBeans. The Initial Developer of the Original
-# Software is Sun Microsystems, Inc. Portions Copyright 2009-2010 Sun
-# Microsystems, Inc. All Rights Reserved.
-#
-# If you wish your version of this file to be governed by only the CDDL
-# or only the GPL Version 2, indicate your decision by adding
-# "[Contributor] elects to include this software in this distribution
-# under the [CDDL or GPL Version 2] license." If you do not indicate a
-# single choice of license, a recipient has the option to distribute
-# your version of this file under either the CDDL, the GPL Version 2 or
-# to extend the choice of license to its licensees as provided above.
-# However, if you add GPL Version 2 code and therefore, elected the GPL
-# Version 2 license, then the option applies only if the new code is
-# made subject to such option by the copyright holder.
 org.netbeans.modules.debugger.ui.models.ColumnModels.createWatchTypeColumn()
 org.netbeans.modules.debugger.ui.models.ColumnModels.createWatchValueColumn()
 org.netbeans.modules.debugger.ui.models.ColumnModels.createWatchToStringColumn()

--- a/spi.debugger.ui/src/META-INF/debugger/WatchesView/org.netbeans.spi.viewmodel.NodeActionsProvider
+++ b/spi.debugger.ui/src/META-INF/debugger/WatchesView/org.netbeans.spi.viewmodel.NodeActionsProvider
@@ -1,42 +1,18 @@
-# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
-# Copyright 2009-2017 Oracle and/or its affiliates. All rights reserved.
-#
-# Oracle and Java are registered trademarks of Oracle and/or its affiliates.
-# Other names may be trademarks of their respective owners.
-#
-# The contents of this file are subject to the terms of either the GNU
-# General Public License Version 2 only ("GPL") or the Common
-# Development and Distribution License("CDDL") (collectively, the
-# "License"). You may not use this file except in compliance with the
-# License. You can obtain a copy of the License at
-# http://www.netbeans.org/cddl-gplv2.html
-# or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
-# specific language governing permissions and limitations under the
-# License.  When distributing the software, include this License Header
-# Notice in each file and include the License file at
-# nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
-# particular file as subject to the "Classpath" exception as provided
-# by Oracle in the GPL Version 2 section of the License file that
-# accompanied this code. If applicable, add the following below the
-# License Header, with the fields enclosed by brackets [] replaced by
-# your own identifying information:
-# "Portions Copyrighted [year] [name of copyright owner]"
-#
-# Contributor(s):
-#
-# The Original Software is NetBeans. The Initial Developer of the Original
-# Software is Sun Microsystems, Inc. Portions Copyright 2009-2010 Sun
-# Microsystems, Inc. All Rights Reserved.
-#
-# If you wish your version of this file to be governed by only the CDDL
-# or only the GPL Version 2, indicate your decision by adding
-# "[Contributor] elects to include this software in this distribution
-# under the [CDDL or GPL Version 2] license." If you do not indicate a
-# single choice of license, a recipient has the option to distribute
-# your version of this file under either the CDDL, the GPL Version 2 or
-# to extend the choice of license to its licensees as provided above.
-# However, if you add GPL Version 2 code and therefore, elected the GPL
-# Version 2 license, then the option applies only if the new code is
-# made subject to such option by the copyright holder.
 org.netbeans.modules.debugger.ui.models.WatchesActionsProvider

--- a/spi.debugger.ui/src/META-INF/debugger/WatchesView/org.netbeans.spi.viewmodel.NodeModel
+++ b/spi.debugger.ui/src/META-INF/debugger/WatchesView/org.netbeans.spi.viewmodel.NodeModel
@@ -1,42 +1,19 @@
-# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
-# Copyright 2009-2017 Oracle and/or its affiliates. All rights reserved.
-#
-# Oracle and Java are registered trademarks of Oracle and/or its affiliates.
-# Other names may be trademarks of their respective owners.
-#
-# The contents of this file are subject to the terms of either the GNU
-# General Public License Version 2 only ("GPL") or the Common
-# Development and Distribution License("CDDL") (collectively, the
-# "License"). You may not use this file except in compliance with the
-# License. You can obtain a copy of the License at
-# http://www.netbeans.org/cddl-gplv2.html
-# or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
-# specific language governing permissions and limitations under the
-# License.  When distributing the software, include this License Header
-# Notice in each file and include the License file at
-# nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
-# particular file as subject to the "Classpath" exception as provided
-# by Oracle in the GPL Version 2 section of the License file that
-# accompanied this code. If applicable, add the following below the
-# License Header, with the fields enclosed by brackets [] replaced by
-# your own identifying information:
-# "Portions Copyrighted [year] [name of copyright owner]"
-#
-# Contributor(s):
-#
-# The Original Software is NetBeans. The Initial Developer of the Original
-# Software is Sun Microsystems, Inc. Portions Copyright 2009-2010 Sun
-# Microsystems, Inc. All Rights Reserved.
-#
-# If you wish your version of this file to be governed by only the CDDL
-# or only the GPL Version 2, indicate your decision by adding
-# "[Contributor] elects to include this software in this distribution
-# under the [CDDL or GPL Version 2] license." If you do not indicate a
-# single choice of license, a recipient has the option to distribute
-# your version of this file under either the CDDL, the GPL Version 2 or
-# to extend the choice of license to its licensees as provided above.
-# However, if you add GPL Version 2 code and therefore, elected the GPL
-# Version 2 license, then the option applies only if the new code is
-# made subject to such option by the copyright holder.
+
 org.netbeans.modules.debugger.ui.models.WatchesNodeModel

--- a/spi.debugger.ui/src/META-INF/debugger/WatchesView/org.netbeans.spi.viewmodel.TableModel
+++ b/spi.debugger.ui/src/META-INF/debugger/WatchesView/org.netbeans.spi.viewmodel.TableModel
@@ -1,42 +1,18 @@
-# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
-# Copyright 2009-2017 Oracle and/or its affiliates. All rights reserved.
-#
-# Oracle and Java are registered trademarks of Oracle and/or its affiliates.
-# Other names may be trademarks of their respective owners.
-#
-# The contents of this file are subject to the terms of either the GNU
-# General Public License Version 2 only ("GPL") or the Common
-# Development and Distribution License("CDDL") (collectively, the
-# "License"). You may not use this file except in compliance with the
-# License. You can obtain a copy of the License at
-# http://www.netbeans.org/cddl-gplv2.html
-# or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
-# specific language governing permissions and limitations under the
-# License.  When distributing the software, include this License Header
-# Notice in each file and include the License file at
-# nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
-# particular file as subject to the "Classpath" exception as provided
-# by Oracle in the GPL Version 2 section of the License file that
-# accompanied this code. If applicable, add the following below the
-# License Header, with the fields enclosed by brackets [] replaced by
-# your own identifying information:
-# "Portions Copyrighted [year] [name of copyright owner]"
-#
-# Contributor(s):
-#
-# The Original Software is NetBeans. The Initial Developer of the Original
-# Software is Sun Microsystems, Inc. Portions Copyright 2009-2010 Sun
-# Microsystems, Inc. All Rights Reserved.
-#
-# If you wish your version of this file to be governed by only the CDDL
-# or only the GPL Version 2, indicate your decision by adding
-# "[Contributor] elects to include this software in this distribution
-# under the [CDDL or GPL Version 2] license." If you do not indicate a
-# single choice of license, a recipient has the option to distribute
-# your version of this file under either the CDDL, the GPL Version 2 or
-# to extend the choice of license to its licensees as provided above.
-# However, if you add GPL Version 2 code and therefore, elected the GPL
-# Version 2 license, then the option applies only if the new code is
-# made subject to such option by the copyright holder.
 org.netbeans.modules.debugger.ui.models.WatchesTableModel

--- a/spi.debugger.ui/src/META-INF/debugger/WatchesView/org.netbeans.spi.viewmodel.TreeModel
+++ b/spi.debugger.ui/src/META-INF/debugger/WatchesView/org.netbeans.spi.viewmodel.TreeModel
@@ -1,42 +1,18 @@
-# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
-# Copyright 2009-2017 Oracle and/or its affiliates. All rights reserved.
-#
-# Oracle and Java are registered trademarks of Oracle and/or its affiliates.
-# Other names may be trademarks of their respective owners.
-#
-# The contents of this file are subject to the terms of either the GNU
-# General Public License Version 2 only ("GPL") or the Common
-# Development and Distribution License("CDDL") (collectively, the
-# "License"). You may not use this file except in compliance with the
-# License. You can obtain a copy of the License at
-# http://www.netbeans.org/cddl-gplv2.html
-# or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
-# specific language governing permissions and limitations under the
-# License.  When distributing the software, include this License Header
-# Notice in each file and include the License file at
-# nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
-# particular file as subject to the "Classpath" exception as provided
-# by Oracle in the GPL Version 2 section of the License file that
-# accompanied this code. If applicable, add the following below the
-# License Header, with the fields enclosed by brackets [] replaced by
-# your own identifying information:
-# "Portions Copyrighted [year] [name of copyright owner]"
-#
-# Contributor(s):
-#
-# The Original Software is NetBeans. The Initial Developer of the Original
-# Software is Sun Microsystems, Inc. Portions Copyright 2009-2010 Sun
-# Microsystems, Inc. All Rights Reserved.
-#
-# If you wish your version of this file to be governed by only the CDDL
-# or only the GPL Version 2, indicate your decision by adding
-# "[Contributor] elects to include this software in this distribution
-# under the [CDDL or GPL Version 2] license." If you do not indicate a
-# single choice of license, a recipient has the option to distribute
-# your version of this file under either the CDDL, the GPL Version 2 or
-# to extend the choice of license to its licensees as provided above.
-# However, if you add GPL Version 2 code and therefore, elected the GPL
-# Version 2 license, then the option applies only if the new code is
-# made subject to such option by the copyright holder.
 org.netbeans.modules.debugger.ui.models.WatchesTreeModel

--- a/spi.debugger.ui/src/META-INF/debugger/org.netbeans.api.debugger.LazyDebuggerManagerListener
+++ b/spi.debugger.ui/src/META-INF/debugger/org.netbeans.api.debugger.LazyDebuggerManagerListener
@@ -1,43 +1,19 @@
-# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
-# Copyright 2009-2017 Oracle and/or its affiliates. All rights reserved.
-#
-# Oracle and Java are registered trademarks of Oracle and/or its affiliates.
-# Other names may be trademarks of their respective owners.
-#
-# The contents of this file are subject to the terms of either the GNU
-# General Public License Version 2 only ("GPL") or the Common
-# Development and Distribution License("CDDL") (collectively, the
-# "License"). You may not use this file except in compliance with the
-# License. You can obtain a copy of the License at
-# http://www.netbeans.org/cddl-gplv2.html
-# or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
-# specific language governing permissions and limitations under the
-# License.  When distributing the software, include this License Header
-# Notice in each file and include the License file at
-# nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
-# particular file as subject to the "Classpath" exception as provided
-# by Oracle in the GPL Version 2 section of the License file that
-# accompanied this code. If applicable, add the following below the
-# License Header, with the fields enclosed by brackets [] replaced by
-# your own identifying information:
-# "Portions Copyrighted [year] [name of copyright owner]"
-#
-# Contributor(s):
-#
-# The Original Software is NetBeans. The Initial Developer of the Original
-# Software is Sun Microsystems, Inc. Portions Copyright 2009-2010 Sun
-# Microsystems, Inc. All Rights Reserved.
-#
-# If you wish your version of this file to be governed by only the CDDL
-# or only the GPL Version 2, indicate your decision by adding
-# "[Contributor] elects to include this software in this distribution
-# under the [CDDL or GPL Version 2] license." If you do not indicate a
-# single choice of license, a recipient has the option to distribute
-# your version of this file under either the CDDL, the GPL Version 2 or
-# to extend the choice of license to its licensees as provided above.
-# However, if you add GPL Version 2 code and therefore, elected the GPL
-# Version 2 license, then the option applies only if the new code is
-# made subject to such option by the copyright holder.
 org.netbeans.modules.debugger.ui.DebuggerManagerListener
 org.netbeans.modules.debugger.ui.PersistenceManager

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/resources/evaluator/code_evaluator.wsmode
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/resources/evaluator/code_evaluator.wsmode
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 
 <!DOCTYPE mode PUBLIC
           "-//NetBeans//DTD Mode Properties 2.0//EN"

--- a/spi.debugger.ui/test/unit/src/META-INF/debugger/netbeans-TestSession/org.netbeans.api.debugger.LazyActionsManagerListener
+++ b/spi.debugger.ui/test/unit/src/META-INF/debugger/netbeans-TestSession/org.netbeans.api.debugger.LazyActionsManagerListener
@@ -1,1 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 org.netbeans.api.debugger.test.TestLazyActionsManagerListener

--- a/spi.debugger.ui/test/unit/src/META-INF/debugger/netbeans-TestSession/org.netbeans.api.debugger.test.TestDebugger
+++ b/spi.debugger.ui/test/unit/src/META-INF/debugger/netbeans-TestSession/org.netbeans.api.debugger.test.TestDebugger
@@ -1,1 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 org.netbeans.api.debugger.test.TestDebugger

--- a/spi.debugger.ui/test/unit/src/META-INF/debugger/netbeans-TestSession/org.netbeans.spi.debugger.ActionsProvider
+++ b/spi.debugger.ui/test/unit/src/META-INF/debugger/netbeans-TestSession/org.netbeans.spi.debugger.ActionsProvider
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 org.netbeans.api.debugger.test.actions.StartActionProvider
 org.netbeans.api.debugger.test.actions.KillActionProvider
 org.netbeans.api.debugger.test.actions.TestDebuggerActionsProvider

--- a/spi.debugger.ui/test/unit/src/META-INF/debugger/netbeans-TestSession/org.netbeans.spi.debugger.DebuggerEngineProvider
+++ b/spi.debugger.ui/test/unit/src/META-INF/debugger/netbeans-TestSession/org.netbeans.spi.debugger.DebuggerEngineProvider
@@ -1,1 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 org.netbeans.api.debugger.test.TestEngineProvider

--- a/spi.debugger.ui/test/unit/src/META-INF/debugger/netbeans-test-TestDICookie/org.netbeans.spi.debugger.SessionProvider
+++ b/spi.debugger.ui/test/unit/src/META-INF/debugger/netbeans-test-TestDICookie/org.netbeans.spi.debugger.SessionProvider
@@ -1,1 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 org.netbeans.api.debugger.test.TestSessionProvider

--- a/spi.debugger.ui/test/unit/src/META-INF/debugger/org.netbeans.api.debugger.LazyDebuggerManagerListener
+++ b/spi.debugger.ui/test/unit/src/META-INF/debugger/org.netbeans.api.debugger.LazyDebuggerManagerListener
@@ -1,1 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 org.netbeans.api.debugger.test.TestLazyDebuggerManagerListener

--- a/spi.debugger.ui/test/unit/src/META-INF/debugger/unittest/annotated/LocalsView/org.netbeans.spi.viewmodel.ColumnModel
+++ b/spi.debugger.ui/test/unit/src/META-INF/debugger/unittest/annotated/LocalsView/org.netbeans.spi.viewmodel.ColumnModel
@@ -1,1 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 org.netbeans.api.debugger.providers.TestColumnModelsProvider.createLocalsToStringColumn()-hidden

--- a/spi.debugger.ui/test/unit/src/META-INF/debugger/unittest/org.netbeans.api.debugger.test.TestLookupServiceFirst
+++ b/spi.debugger.ui/test/unit/src/META-INF/debugger/unittest/org.netbeans.api.debugger.test.TestLookupServiceFirst
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 # comment 1
 
 # comment 2

--- a/spi.debugger.ui/test/unit/src/META-INF/debugger/unittest/org.netbeans.api.debugger.test.TestLookupServiceInterface
+++ b/spi.debugger.ui/test/unit/src/META-INF/debugger/unittest/org.netbeans.api.debugger.test.TestLookupServiceInterface
@@ -1,1 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 org.netbeans.api.debugger.test.TestLookupServiceSecond


### PR DESCRIPTION
  - No external binaries.
  - Removed previous license from many META-INF files.
  - Two files to be handled centrally (*.sig, manifest.mf)
  - Two tests failing (both before and after changes): org.netbeans.api.debugger.ProvidersAnnotationTest and org.netbeans.api.debugger.WatchesTest
  - No other licensing issues found.