### PR TITLE
[NETBEANS-54] Module Review o.apache.ws.commons.util

### DIFF
--- a/o.apache.ws.commons.util/external/binaries-list
+++ b/o.apache.ws.commons.util/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-52BEF8900248E7AB86C5743ED14A48AD787BF457 ws-commons-util-1.0.1.jar
+126E80FF798FECE634BC94E61F8BE8A8DA00BE60 org.apache.ws.commons:ws-commons-util:1.0.1


### PR DESCRIPTION
  - Updated maven coordinates for Apache WS Commons Util (Apache 2.0)
  - No notice found at http://svn.apache.org/viewvc/webservices/commons/trunk/modules/util/
  - No other licensing issues found (manifest.mf to be handled centrally)