### PR TITLE
[NETBEANS-54] Module Review o.apache.xmlrpc

### DIFF
--- a/o.apache.xmlrpc/external/binaries-list
+++ b/o.apache.xmlrpc/external/binaries-list
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-64F5BEEADD2A239C4BC354B8DFDB97CF7FDD9983 xmlrpc-client-3.0.jar
-8FA16AD28B5E79A7CD52B8B72985B0AE8CCD6ADF xmlrpc-common-3.0.jar
-D6917BF718583002CBE44E773EE21E2DF08ADC71 xmlrpc-server-3.0.jar
+64F5BEEADD2A239C4BC354B8DFDB97CF7FDD9983 org.apache.xmlrpc:xmlrpc-client:3.0
+8FA16AD28B5E79A7CD52B8B72985B0AE8CCD6ADF org.apache.xmlrpc:xmlrpc-common:3.0
+D6917BF718583002CBE44E773EE21E2DF08ADC71 org.apache.xmlrpc:xmlrpc-server:3.0
+


### PR DESCRIPTION
  - Added three entries in binaries-list with Maven coordinates for Apache XMLRPC 3.0 files (Apache 2.0)
  - No notice files found at https://svn.apache.org/repos/asf/webservices/archive/xmlrpc/tags/XMLRPC_3_0/
  - No other licensing issues found.