### PR TITLE
[NETBEANS-54] Module Review o.eclipse.core.contenttype

### DIFF
--- a/o.eclipse.core.contenttype/external/binaries-list
+++ b/o.eclipse.core.contenttype/external/binaries-list
@@ -15,5 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 # AA2671239EBB762FEEE8B908E9F35473A72AFE1B org.eclipse.core.contenttype_3.4.100.v20110423-0524_nosignature.jar
-# http://repo1.maven.org/maven2/org/jibx/config/3rdparty/org/eclipse/org.eclipse.core.contenttype/3.4.100.v20110423-0524/org.eclipse.core.contenttype-3.4.100.v20110423-0524.jar
-1232efbde2930d21d106850bd166c9b27f743ba8 org.jibx.config.3rdparty.org.eclipse:org.eclipse.core.contenttype:3.4.100.v20110423-0524
+1232EFBDE2930D21D106850BD166C9B27F743BA8 org.jibx.config.3rdparty.org.eclipse:org.eclipse.core.contenttype:3.4.100.v20110423-0524

--- a/o.eclipse.core.contenttype/external/binaries-list
+++ b/o.eclipse.core.contenttype/external/binaries-list
@@ -14,4 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-AA2671239EBB762FEEE8B908E9F35473A72AFE1B org.eclipse.core.contenttype_3.4.100.v20110423-0524_nosignature.jar
+# AA2671239EBB762FEEE8B908E9F35473A72AFE1B org.eclipse.core.contenttype_3.4.100.v20110423-0524_nosignature.jar
+# http://repo1.maven.org/maven2/org/jibx/config/3rdparty/org/eclipse/org.eclipse.core.contenttype/3.4.100.v20110423-0524/org.eclipse.core.contenttype-3.4.100.v20110423-0524.jar
+1232efbde2930d21d106850bd166c9b27f743ba8 org.jibx.config.3rdparty.org.eclipse:org.eclipse.core.contenttype:3.4.100.v20110423-0524

--- a/o.eclipse.core.contenttype/nbproject/project.properties
+++ b/o.eclipse.core.contenttype/nbproject/project.properties
@@ -14,6 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-release.external/org.eclipse.core.contenttype_3.4.100.v20110423-0524_nosignature.jar=modules/org-eclipse-core-contenttype.jar
+release.external/org.eclipse.core.contenttype-3.4.100.v20110423-0524.jar=modules/org-eclipse-core-contenttype.jar
 is.autoload=true
 nbm.module.author=Tomas Stupka

--- a/o.eclipse.core.contenttype/nbproject/project.xml
+++ b/o.eclipse.core.contenttype/nbproject/project.xml
@@ -28,7 +28,7 @@
            <public-packages/>
            <class-path-extension>
                <runtime-relative-path>org-eclipse-core-contenttype.jar</runtime-relative-path>
-                <binary-origin>external/org.eclipse.core.contenttype_3.4.100.v20110423-0524_nosignature.jar</binary-origin>
+                <binary-origin>external/org.eclipse.core.contenttype-3.4.100.v20110423-0524.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>


### PR DESCRIPTION
  - Added maven coordinates for for org/eclipse/core/contenttype (EPL 1.0)
  - Updated nbproject/* to reflect the change in the binary.
  - NOTE: Maven jar file is signed (original was not).
  - No other licensing issues found.