### PR TITLE
[NETBEANS-54] Module Review o.eclipse.core.jobs

### DIFF
--- a/o.eclipse.core.jobs/external/binaries-list
+++ b/o.eclipse.core.jobs/external/binaries-list
@@ -14,4 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-1605B38BB28EAE32C11EAB8F9E238A497754A5B8 org.eclipse.core.jobs-3.5.101_nosignature.jar
+#1605B38BB28EAE32C11EAB8F9E238A497754A5B8 org.eclipse.core.jobs-3.5.101_nosignature.jar
+7e99e30a7f23423a250744af33009fc2fbcdf241 org.eclipse.core:org.eclipse.core.jobs:3.5.100

--- a/o.eclipse.core.jobs/external/binaries-list
+++ b/o.eclipse.core.jobs/external/binaries-list
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 #1605B38BB28EAE32C11EAB8F9E238A497754A5B8 org.eclipse.core.jobs-3.5.101_nosignature.jar
-7e99e30a7f23423a250744af33009fc2fbcdf241 org.eclipse.core:org.eclipse.core.jobs:3.5.100
+7E99E30A7F23423A250744AF33009FC2FBCDF241 org.eclipse.core:org.eclipse.core.jobs:3.5.100

--- a/o.eclipse.core.jobs/nbproject/project.properties
+++ b/o.eclipse.core.jobs/nbproject/project.properties
@@ -14,6 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-release.external/org.eclipse.core.jobs-3.5.101_nosignature.jar=modules/org-eclipse-core-jobs.jar
+release.external/org.eclipse.core.jobs-3.5.100.jar=modules/org-eclipse-core-jobs.jar
 is.autoload=true
 nbm.module.author=Tomas Stupka

--- a/o.eclipse.core.jobs/nbproject/project.xml
+++ b/o.eclipse.core.jobs/nbproject/project.xml
@@ -36,7 +36,7 @@
             </public-packages>
             <class-path-extension>
                 <runtime-relative-path>org-eclipse-core-jobs.jar</runtime-relative-path>
-                <binary-origin>external/org.eclipse.core.jobs-3.5.101_nosignature.jar</binary-origin>
+                <binary-origin>external/org.eclipse.core.jobs-3.5.100.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>


### PR DESCRIPTION
  - Exact version 3.5.101 could not be found in Maven, downgrading to 3.5.100
  - Updated binaries-list with maven coordinates for eclipse core jobs 3.5.100 (EPL 1.0)
  - Updated nbproject/* accordingly.
  - No other licensing issues found.