### PR TITLE
Renamed VerifyFileTest class  to exclude it from TestSuite run as it depends on deleted resource

### DIFF
--- a/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/VerifyFileTestDisabled.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/VerifyFileTestDisabled.java
@@ -34,13 +34,13 @@ import java.util.logging.Logger;
 import org.netbeans.api.autoupdate.TestUtils;
 import org.netbeans.junit.NbTestCase;
 
-public class VerifyFileTest extends NbTestCase {
+public class VerifyFileTestDisabled extends NbTestCase {
 
-    private static final Logger LOG = Logger.getLogger(VerifyFileTest.class.getName());
+    private static final Logger LOG = Logger.getLogger(VerifyFileTestDisabled.class.getName());
 
     private KeyStore ks;
 
-    public VerifyFileTest(String testName) {
+    public VerifyFileTestDisabled(String testName) {
         super(testName);
     }
 


### PR DESCRIPTION
Renamed TestFile VerifyFileTest to VerifyFileTestDisabled to exclude it from TestSuite run as it is dependent on resource foo.jks deleted during Apache Code Donation . We can't comment out only the failing test methods as test class should have at least one test method and in this case all test methods have issues.