### PR TITLE
[NETBEANS-94] Cannot build NB Javadocs on Windows

### DIFF
--- a/nbbuild/javadoctools/template.xml
+++ b/nbbuild/javadoctools/template.xml
@@ -276,7 +276,7 @@ cause it to fail.
     </target>
     
     <target name="javadoc-exec-packages" depends="javadoc-init,javadoc-generate-references,javadoc-generate-overview,javadoc-exec-condition,javadoc-check-timestamps,javadoc-make-plain-title,javadoc-make-hyperlinked-title,javadoc-exec-condition,-javadoc-set-footer" unless="javadoc.exec.packages">
-        <javadoc source="${javac.source}" author="false" destdir="${javadoc.out.dir}" packagenames="${javadoc.packages}" stylesheetfile="${javadoc.css.main}" windowtitle="${javadoc.title}" overview="${javadoc.overview}" splitindex="true" use="true" version="false" encoding="UTF-8">
+        <javadoc source="${javac.source}" author="false" destdir="${javadoc.out.dir}" packagenames="${javadoc.packages}" stylesheetfile="${javadoc.css.main}" windowtitle="${javadoc.title}" overview="${javadoc.overview}" splitindex="true" use="true" version="false" useexternalfile="true" encoding="UTF-8">
             <sourcepath>
                 <pathelement location="${javadoc.docfiles}"/>
                 <pathelement location="${javadoc.src}"/>


### PR DESCRIPTION
Note that the `useexternalfile` attribute has been on the Ant `javadoc-exec-files` target (see line 298) for at least the last 10 years, but for some reason it wasn't on the `javadoc-exec-packages` target. Now fixed.

Description for `useexternalfile` attribute is [here](https://ant.apache.org/manual/Tasks/javadoc.html).