### PR TITLE
[NETBEANS-54] Module Review maven.embedder

### DIFF
--- a/maven.embedder/external/binaries-list
+++ b/maven.embedder/external/binaries-list
@@ -14,6 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-A2AC1CD690AB4C80DEFE7F9BCE14D35934C35CEC jdom-1.0.jar
-BF206C4AA93C74A739FBAF1F1C78E3AD5F167245 maven-dependency-tree-2.0.jar
-2DDF9BB8C3B41BC2891832A6D6FC25F8BF41D77F apache-maven-3.3.9-bin.zip
+A2AC1CD690AB4C80DEFE7F9BCE14D35934C35CEC jdom:jdom:1.0
+BF206C4AA93C74A739FBAF1F1C78E3AD5F167245 org.apache.maven.shared:maven-dependency-tree:2.0
+2DDF9BB8C3B41BC2891832A6D6FC25F8BF41D77F org.apache.maven:apache-maven:3.3.9:bin@zip

--- a/maven.embedder/external/jdom-1.0-notice.txt
+++ b/maven.embedder/external/jdom-1.0-notice.txt
@@ -1,0 +1,49 @@
+Copyright (C) 2000-2004 Jason Hunter & Brett McLaughlin.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions, and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions, and the disclaimer that follows
+   these conditions in the documentation and/or other materials
+   provided with the distribution.
+
+3. The name "JDOM" must not be used to endorse or promote products
+   derived from this software without prior written permission.  For
+   written permission, please contact <request_AT_jdom_DOT_org>.
+
+4. Products derived from this software may not be called "JDOM", nor
+   may "JDOM" appear in their name, without prior written permission
+   from the JDOM Project Management <request_AT_jdom_DOT_org>.
+
+In addition, we request (but do not require) that you include in the
+end-user documentation provided with the redistribution and/or in the
+software itself an acknowledgement equivalent to the following:
+    "This product includes software developed by the
+     JDOM Project (http://www.jdom.org/)."
+Alternatively, the acknowledgment may be graphical using the logos
+available at http://www.jdom.org/images/logos.
+
+THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED.  IN NO EVENT SHALL THE JDOM AUTHORS OR THE PROJECT
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+
+This software consists of voluntary contributions made by many
+individuals on behalf of the JDOM Project and was originally
+created by Jason Hunter <jhunter_AT_jdom_DOT_org> and
+Brett McLaughlin <brett_AT_jdom_DOT_org>.  For more information
+on the JDOM Project, please see <http://www.jdom.org/>.


### PR DESCRIPTION
- binaries-list updated to use maven coords
- added notice for jdom license (please double check)
- did not add notice for maven-dependency-tree (already apache licensed)