### PR TITLE
[NETBEANS-54] Module Review debugger.jpda.ui

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@
 /db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/parser/SQLParserTokenManager.java
 /db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/parser/Token.java
 /db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/parser/TokenMgrError.java
+/debugger.jpda.ui/test/qa-functional/data/debugTestProject/nbproject/private/
+/debugger.jpda.ui/test/qa-functional/data/debugTestProjectAnt/nbproject/private/
 /hibernate/src/org/netbeans/modules/hibernate/resources/hibernate-configuration-3.0.dtd
 /hibernate/src/org/netbeans/modules/hibernate/resources/hibernate-mapping-3.0.dtd
 /hibernate/src/org/netbeans/modules/hibernate/resources/hibernate-reverse-engineering-3.0.dtd

--- a/debugger.jpda.ui/test/qa-functional/data/debugTestProject/src/examples/advanced/README.txt
+++ b/debugger.jpda.ui/test/qa-functional/data/debugTestProject/src/examples/advanced/README.txt
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 This package contains the MemoryView program, which displays a window
 displaying the current JVM memory and allows you to explicitly run
 garbage collection.


### PR DESCRIPTION
- no external library
- checked Rat report: add the license header to genfiles.properties and README.txt
- skimmed through the module, did not notice additional problems