### PR TITLE
[NETBEANS-54] Module Review java.j2seplatform

### DIFF
--- a/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/queries/Bundle.properties
+++ b/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/queries/Bundle.properties
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Contributor(s):
 # {0} - the root to attach Javadoc to
 TXT_AttachJavadocTo=Attach Javadoc to "{0}"
 # {0} - the root to attach Sources to

--- a/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/queries/Bundle.properties
+++ b/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/queries/Bundle.properties
@@ -1,38 +1,19 @@
-# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
 #
-# Copyright (c) 2011, 2016 Oracle and/or its affiliates. All rights reserved.
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
-# Oracle and Java are registered trademarks of Oracle and/or its affiliates.
-# Other names may be trademarks of their respective owners.
-#
-# The contents of this file are subject to the terms of either the GNU
-# General Public License Version 2 only ("GPL") or the Common
-# Development and Distribution License("CDDL") (collectively, the
-# "License"). You may not use this file except in compliance with the
-# License. You can obtain a copy of the License at
-# http://www.netbeans.org/cddl-gplv2.html
-# or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
-# specific language governing permissions and limitations under the
-# License.  When distributing the software, include this License Header
-# Notice in each file and include the License file at
-# nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
-# particular file as subject to the "Classpath" exception as provided
-# by Oracle in the GPL Version 2 section of the License file that
-# accompanied this code. If applicable, add the following below the
-# License Header, with the fields enclosed by brackets [] replaced by
-# your own identifying information:
-# "Portions Copyrighted [year] [name of copyright owner]"
-#
-# If you wish your version of this file to be governed by only the CDDL
-# or only the GPL Version 2, indicate your decision by adding
-# "[Contributor] elects to include this software in this distribution
-# under the [CDDL or GPL Version 2] license." If you do not indicate a
-# single choice of license, a recipient has the option to distribute
-# your version of this file under either the CDDL, the GPL Version 2 or
-# to extend the choice of license to its licensees as provided above.
-# However, if you add GPL Version 2 code and therefore, elected the GPL
-# Version 2 license, then the option applies only if the new code is
-# made subject to such option by the copyright holder.
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 #
 # Contributor(s):
 # {0} - the root to attach Javadoc to

--- a/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/resources/templates/defaultPlatform.xml
+++ b/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/resources/templates/defaultPlatform.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <!DOCTYPE platform PUBLIC '-//NetBeans//DTD Java PlatformDefinition 1.0//EN' 'http://www.netbeans.org/dtds/java-platformdefinition-1_0.dtd'>
 <platform default="yes">
 </platform>

--- a/spellchecker.bindings.htmlxml/src/org/netbeans/modules/spellchecker/bindings/htmlxml/HtmlXmlTokenListProvider.java
+++ b/spellchecker.bindings.htmlxml/src/org/netbeans/modules/spellchecker/bindings/htmlxml/HtmlXmlTokenListProvider.java
@@ -1,36 +1,20 @@
-/*
- * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- * Copyright 1997-2010 Oracle and/or its affiliates. All rights reserved.
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Oracle and Java are registered trademarks of Oracle and/or its affiliates.
- * Other names may be trademarks of their respective owners.
- *
- * The contents of this file are subject to the terms of either the GNU
- * General Public License Version 2 only ("GPL") or the Common
- * Development and Distribution License("CDDL") (collectively, the
- * "License"). You may not use this file except in compliance with the
- * License. You can obtain a copy of the License at
- * http://www.netbeans.org/cddl-gplv2.html
- * or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
- * specific language governing permissions and limitations under the
- * License.  When distributing the software, include this License Header
- * Notice in each file and include the License file at
- * nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the GPL Version 2 section of the License file that
- * accompanied this code. If applicable, add the following below the
- * License Header, with the fields enclosed by brackets [] replaced by
- * your own identifying information:
- * "Portions Copyrighted [year] [name of copyright owner]"
- *
- * Contributor(s):
- *
- * The Original Software is NetBeans. The Initial Developer of the Original
- * Software is Sun Microsystems, Inc. Portions Copyright 1997-2008 Sun
- * Microsystems, Inc. All Rights Reserved.
- * 
- * Portions Copyrighted 2007-2008 Stefan Riha, Roland Poppenreiter
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package org.netbeans.modules.spellchecker.bindings.htmlxml;
 

--- a/spellchecker.bindings.properties/src/org/netbeans/modules/spellchecker/bindings/properties/PropertiesTokenListProvider.java
+++ b/spellchecker.bindings.properties/src/org/netbeans/modules/spellchecker/bindings/properties/PropertiesTokenListProvider.java
@@ -1,47 +1,20 @@
-/*
- * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- * Copyright 1997-2010 Oracle and/or its affiliates. All rights reserved.
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Oracle and Java are registered trademarks of Oracle and/or its affiliates.
- * Other names may be trademarks of their respective owners.
- *
- * The contents of this file are subject to the terms of either the GNU
- * General Public License Version 2 only ("GPL") or the Common
- * Development and Distribution License("CDDL") (collectively, the
- * "License"). You may not use this file except in compliance with the
- * License. You can obtain a copy of the License at
- * http://www.netbeans.org/cddl-gplv2.html
- * or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
- * specific language governing permissions and limitations under the
- * License.  When distributing the software, include this License Header
- * Notice in each file and include the License file at
- * nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the GPL Version 2 section of the License file that
- * accompanied this code. If applicable, add the following below the
- * License Header, with the fields enclosed by brackets [] replaced by
- * your own identifying information:
- * "Portions Copyrighted [year] [name of copyright owner]"
- *
- * Contributor(s):
- *
- * The Original Software is NetBeans. The Initial Developer of the Original
- * Software is Sun Microsystems, Inc. Portions Copyright 1997-2008 Sun
- * Microsystems, Inc. All Rights Reserved.
- * 
- * Portions Copyrighted 2007-2008 Stefan Riha, Roland Poppenreiter
- *
- * If you wish your version of this file to be governed by only the CDDL
- * or only the GPL Version 2, indicate your decision by adding
- * "[Contributor] elects to include this software in this distribution
- * under the [CDDL or GPL Version 2] license." If you do not indicate a
- * single choice of license, a recipient has the option to distribute
- * your version of this file under either the CDDL, the GPL Version 2 or
- * to extend the choice of license to its licensees as provided above.
- * However, if you add GPL Version 2 code and therefore, elected the GPL
- * Version 2 license, then the option applies only if the new code is
- * made subject to such option by the copyright holder.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package org.netbeans.modules.spellchecker.bindings.properties;
 


### PR DESCRIPTION
[NETBEANS-54] Module Review java.j2seplatform

-no external library

-change licence header from Oracle to Apache:
java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/queries/Bundle.properties

-add Apache licence
java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/resources/templates/defaultPlatform.xml

-skimmed through module, did not notice additional problems