### PR TITLE
Fix unittests for Netbeans Build system

### DIFF
--- a/nbbuild/nbproject/project.xml
+++ b/nbbuild/nbproject/project.xml
@@ -202,14 +202,14 @@
             <subprojects/>
             <project-license>cddl-netbeans-sun</project-license>
         </general-data>
-        <java-data xmlns="http://www.netbeans.org/ns/freeform-project-java/2">
+        <java-data xmlns="http://www.netbeans.org/ns/freeform-project-java/4">
             <compilation-unit>
                 <package-root>antsrc</package-root>
                 <classpath mode="compile">${ant.core.lib}:${nb_all}/javahelp/external/jhall-2.0_05.jar</classpath>
                 <classpath mode="boot">${nbjdk.bootclasspath}</classpath>
                 <built-to>${nb.build.dir}/antclasses</built-to>
                 <built-to>${nbantext.jar}</built-to>
-                <source-level>1.5</source-level>
+                <source-level>1.8</source-level>
             </compilation-unit>
             <compilation-unit>
                 <package-root>test/unit/src</package-root>
@@ -217,7 +217,7 @@
                 <classpath mode="compile">${test.unit.cp}</classpath>
                 <classpath mode="boot">${nbjdk.bootclasspath}</classpath>
                 <built-to>${nb.build.dir}/test/unit/classes</built-to>
-                <source-level>1.5</source-level>
+                <source-level>1.8</source-level>
             </compilation-unit>
         </java-data>
     </configuration>

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/CheckLicenseAnt.xml
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/CheckLicenseAnt.xml
@@ -10,12 +10,12 @@
    <fileset dir='${dir}'>
     <include name="${include}" />
    </fileset>
-   <convert token='^( *[^ ]) *DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.' replace='Ahoj\nJardo' prefix='true'/>
-   <convert token=' *DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.'>
+   <convert token='^( *[^ ]) *Licensed to the Apache Software Foundation \(ASF\) under one' replace='Ahoj\nJardo' prefix='true'/>
+   <convert token=' *Licensed to the Apache Software Foundation \(ASF\) under one'>
        <line text='Ahoj'/>
        <line text='Jardo'/>
    </convert>
-   <convert token=' *Oracle and Java.*are.*registered.*trademarks.*of.*Oracle.*and.*or.*its.* affiliates.'
+   <convert token=' *or more contributor.*license.*agreements\..*See.*the NOTICE file'
    >
        <line text='New'/>
        <line text='Warning'/>

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/CheckLicenseHtmlExample.xml
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/CheckLicenseHtmlExample.xml
@@ -1,22 +1,20 @@
 <!--
-
-    Licensed to the Apache Software Foundation (ASF) under one
-    or more contributor license agreements.  See the NOTICE file
-    distributed with this work for additional information
-    regarding copyright ownership.  The ASF licenses this file
-    to you under the Apache License, Version 2.0 (the
-    "License"); you may not use this file except in compliance
-    with the License.  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing,
-    software distributed under the License is distributed on an
-    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-    KIND, either express or implied.  See the License for the
-    specific language governing permissions and limitations
-    under the License.
-
+  - Licensed to the Apache Software Foundation (ASF) under one
+  - or more contributor license agreements.  See the NOTICE file
+  - distributed with this work for additional information
+  - regarding copyright ownership.  The ASF licenses this file
+  - to you under the Apache License, Version 2.0 (the
+  - "License"); you may not use this file except in compliance
+  - with the License.  You may obtain a copy of the License at
+  -
+  -   http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing,
+  - software distributed under the License is distributed on an
+  - "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  - KIND, either express or implied.  See the License for the
+  - specific language governing permissions and limitations
+  - under the License.
 -->
 
 <HTML><BODY>

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/CheckLicensePropertiesExample.properties
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/CheckLicensePropertiesExample.properties
@@ -14,7 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
 OpenIDE-Module-Name=Settings API
 OpenIDE-Module-Short-Description=A library for storing settings in custom formats.
 OpenIDE-Module-Long-Description=\

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/CheckLicenseTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/CheckLicenseTest.java
@@ -201,31 +201,23 @@ public class CheckLicenseTest extends TestBase {
     
     public void testReplaceJavaLicense() throws Exception {
         java.io.File tmp = extractString(
-"/*\n" +
-" * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.\n" +
+"/**\n" +
+" * Licensed to the Apache Software Foundation (ASF) under one\n" +
+" * or more contributor license agreements.  See the NOTICE file\n" +
+" * distributed with this work for additional information\n" +
+" * regarding copyright ownership.  The ASF licenses this file\n" +
+" * to you under the Apache License, Version 2.0 (the\n" +
+" * \"License\"); you may not use this file except in compliance\n" +
+" * with the License.  You may obtain a copy of the License at\n" +
 " *\n" +
-" * Copyright 2012 Oracle and/or its affiliates. All rights reserved.\n" +
+" *   http://www.apache.org/licenses/LICENSE-2.0\n" +
 " *\n" +
-" * Oracle and Java are registered trademarks of Oracle and/or its affiliates.\n" +
-" * Other names may be trademarks of their respective owners.\n" +
-" *\n" +
-" * The contents of this file are subject to the terms of either the GNU\n" +
-" * General Public License Version 2 only (\"GPL\") or the Common\n" +
-" * Development and Distribution License(\"CDDL\") (collectively, the\n" +
-" * \"License\"). You may not use this file except in compliance with the\n" +
-" * License. You can obtain a copy of the License at\n" +
-" * http://www.netbeans.org/cddl-gplv2.html\n" +
-" * or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the\n" +
-" * specific language governing permissions and limitations under the\n" +
-" * License.  When distributing the software, include this License Header\n" +
-" * Notice in each file and include the License file at\n" +
-" * nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this\n" +
-" * particular file as subject to the \"Classpath\" exception as provided\n" +
-" * by Oracle in the GPL Version 2 section of the License file that\n" +
-" * accompanied this code. If applicable, add the following below the\n" +
-" * License Header, with the fields enclosed by brackets [] replaced by\n" +
-" * your own identifying information:\n" +
-" * \"Portions Copyrighted [year] [name of copyright owner]\"\n" +
+" * Unless required by applicable law or agreed to in writing,\n" +
+" * software distributed under the License is distributed on an\n" +
+" * \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY\n" +
+" * KIND, either express or implied.  See the License for the\n" +
+" * specific language governing permissions and limitations\n" +
+" * under the License.\n" +
 " */"
         );
         File java = new File(tmp.getParentFile(), "MyTest.java");
@@ -630,15 +622,6 @@ public class CheckLicenseTest extends TestBase {
                 }
             }
         }
-        
-        {
-            if (content.indexOf("2002") != -1) {
-                fail("No reference to year 2002:\n" + content);
-            }
-            if (content.indexOf("2006") == -1) {
-                fail("There should be a ref to 2006:\n" + content);
-            }
-        }
     }        
 
     private static boolean isWindows() {
@@ -686,15 +669,6 @@ public class CheckLicenseTest extends TestBase {
             Matcher m = Pattern.compile("^ *New. *Warning", Pattern.MULTILINE | Pattern.DOTALL).matcher(content);
             if (!m.find()) {
                 fail("warning shall be there:\n" + content);
-            }
-        }
-        
-        {
-            if (content.indexOf("2002") != -1) {
-                fail("No reference to year 2002:\n" + content);
-            }
-            if (content.indexOf("2006") == -1) {
-                fail("There should be a ref to 2006:\n" + content);
             }
         }
     }        

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/CheckLicenseXmlExample.xml
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/CheckLicenseXmlExample.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
     distributed with this work for additional information
@@ -17,7 +16,6 @@
     KIND, either express or implied.  See the License for the
     specific language governing permissions and limitations
     under the License.
-
 -->
 <project basedir="." default="netbeans" name="javacvs/libmodule">
     <import file="../../nbbuild/templates/projectized.xml"/>

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/ModuleListParserTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/ModuleListParserTest.java
@@ -236,23 +236,24 @@ public class ModuleListParserTest extends TestBase {
         ModuleListParser.Entry e = p.findByCodeNameBase(cnb);
         assertNotNull("found netigso module", e);
     }
-    
-    public void testScanSourcesAndBinariesForExternalStandaloneModule() throws Exception {
-        Hashtable<String,Object> properties = new Hashtable<String,Object>();
-        properties.put("cluster.path.final", filePath(nball, "apisupport.ant/test/unit/data/example-external-projects/suite3/nbplatform/platform5") +
-                File.pathSeparator + filePath(nball, "apisupport.ant/test/unit/data/example-external-projects/suite3/nbplatform/random"));
-        properties.put("basedir", filePath(nball, "apisupport.ant/test/unit/data/example-external-projects/suite3/dummy-project"));
-        properties.put("project", filePath(nball, "apisupport.ant/test/unit/data/example-external-projects/suite3/dummy-project"));
-        ModuleListParser p = new ModuleListParser(properties, ModuleType.STANDALONE, null);
-        ModuleListParser.Entry e = p.findByCodeNameBase("org.netbeans.examples.modules.dummy");
-        assertNotNull("found myself", e);
-        assertEquals("org.netbeans.examples.modules.dummy", e.getCnb());
-        assertEquals(file(nball, "apisupport.ant/test/unit/data/example-external-projects/suite3/dummy-project/build/cluster/modules/org-netbeans-examples-modules-dummy.jar"), e.getJar());
-        assertEquals(Collections.EMPTY_LIST, Arrays.asList(e.getClassPathExtensions()));
-        e = p.findByCodeNameBase("org.netbeans.modules.classfile");
-        assertNotNull("found (fake) netbeans.org module by its binary", e);
-        assertEquals("org.netbeans.modules.classfile", e.getCnb());
-    }
+
+//    Disabled test - referenced project files were not donated to apache
+//    public void testScanSourcesAndBinariesForExternalStandaloneModule() throws Exception {
+//        Hashtable<String,Object> properties = new Hashtable<String,Object>();
+//        properties.put("cluster.path.final", filePath(nball, "apisupport.ant/test/unit/data/example-external-projects/suite3/nbplatform/platform5") +
+//                File.pathSeparator + filePath(nball, "apisupport.ant/test/unit/data/example-external-projects/suite3/nbplatform/random"));
+//        properties.put("basedir", filePath(nball, "apisupport.ant/test/unit/data/example-external-projects/suite3/dummy-project"));
+//        properties.put("project", filePath(nball, "apisupport.ant/test/unit/data/example-external-projects/suite3/dummy-project"));
+//        ModuleListParser p = new ModuleListParser(properties, ModuleType.STANDALONE, null);
+//        ModuleListParser.Entry e = p.findByCodeNameBase("org.netbeans.examples.modules.dummy");
+//        assertNotNull("found myself", e);
+//        assertEquals("org.netbeans.examples.modules.dummy", e.getCnb());
+//        assertEquals(file(nball, "apisupport.ant/test/unit/data/example-external-projects/suite3/dummy-project/build/cluster/modules/org-netbeans-examples-modules-dummy.jar"), e.getJar());
+//        assertEquals(Collections.EMPTY_LIST, Arrays.asList(e.getClassPathExtensions()));
+//        e = p.findByCodeNameBase("org.netbeans.modules.classfile");
+//        assertNotNull("found (fake) netbeans.org module by its binary", e);
+//        assertEquals("org.netbeans.modules.classfile", e.getCnb());
+//    }
 
     private File generateJar (File f, String[] content, Manifest manifest) throws IOException {
         JarOutputStream os = new JarOutputStream (new FileOutputStream (f), manifest);

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/extlibs/DownloadBinariesTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/extlibs/DownloadBinariesTest.java
@@ -27,6 +27,7 @@ import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.types.FileSet;
 import org.netbeans.junit.NbTestCase;
+import org.netbeans.nbbuild.extlibs.DownloadBinaries.MavenCoordinate;
 
 public class DownloadBinariesTest extends NbTestCase {
 
@@ -84,15 +85,15 @@ public class DownloadBinariesTest extends NbTestCase {
     }
 
     public void testIsNormalDownload() {
-        boolean is = DownloadBinaries.isMavenFile("5C372AB96C721258C5C12BB8EAD291BBBA5DACE6", "hello");
+        boolean is = MavenCoordinate.isMavenFile("hello");
         assertFalse("This is hg.netbeans.org hashed file", is);
     }
 
     public void testIsMavenDownload() {
-        final String[] hashAndId = new String[] { "CEC2829EC391CB404AD32EB2D08F879C418B745B", "org.netbeans.html:xhr4j:1.3" };
-        boolean is = DownloadBinaries.isMavenFile(hashAndId);
+        final String id = "org.netbeans.html:xhr4j:1.3";
+        boolean is = MavenCoordinate.isMavenFile(id);
         assertTrue("Contains co-ordinates", is);
-        String targetName = DownloadBinaries.mavenFileName(hashAndId);
+        String targetName = MavenCoordinate.fromGradleFormat(id).toArtifactFilename();
         assertEquals("xhr4j-1.3.jar", targetName);
     }
 


### PR DESCRIPTION
As indicated in the comment to PR #130 (cache external binaries
also for downloads from maven central) [1] the change to the
Netbeans Build System done in [2] and the changes to license headers
caused unittests in nbbuild to fail. These changesets fix this.

[1] https://github.com/apache/incubator-netbeans/pull/130#issuecomment-336243405
[2] https://github.com/matthiasblaesing/incubator-netbeans/commit/5c773910524b785e35c5b45d73c5ac42534669d3