### PR TITLE
[NETBEANS-54] Module Review libs.osgi (followup)

### DIFF
--- a/libs.osgi/build.xml
+++ b/libs.osgi/build.xml
@@ -22,4 +22,29 @@
 <project basedir="." default="netbeans" name="libs.osgi">
     <description>Builds, tests, and runs the project org.netbeans.libs.osgi</description>
     <import file="../nbbuild/templates/projectized.xml"/>
+    
+    <!-- A task to check if the binary 'external/osgi.cmpn-4.2.jar' exists -->
+    <target name="-check-requires-patching-maven-sources">
+        <available file="external/osgi.cmpn-4.2.jar" property="sources-already-patched" />
+    </target>
+    
+    <!-- 
+         '-javac-init' task is invoked after maven sources have been downloaded 
+         to 'external/org.osgi.compendium-4.2.0.jar'
+         (see external/binaries-list).
+         Netbeans had its own copy of osgi.cmpn-4.2.jar, which is identical to
+         the downloaded binary. The downloaded binary contains the source code
+         in addition to the compiled class files.
+         The sources are now stripped from the binary to create the original file
+         netbeans used to bundle.
+    -->
+    <target name="-prepare-patched-binary" depends="-check-requires-patching-maven-sources" unless="sources-already-patched">
+        <echo message="Patching org.osgi.compendium-4.2.0 for Netbeans..." />
+        <zip destfile="external/osgi.cmpn-4.2.jar">
+            <zipfileset src="external/org.osgi.compendium-4.2.0.jar" excludes="OSGI-OPT/**" />
+        </zip>
+    </target>
+    
+    <!-- Hook into harness "-javac-init" task -->
+    <target name="-javac-init" depends="-prepare-patched-binary, projectized-common.-javac-init" />
 </project>

--- a/libs.osgi/external/binaries-list
+++ b/libs.osgi/external/binaries-list
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-972E6455724DC6ADB1C1912F53B5E3D7DF20C5FD org.netbeans.external:osgi.cmpn:4.2
+1E506145EC53132BCE79CE8798D98026B598FD48 org.osgi:org.osgi.compendium:4.2.0
 2F2FBFF3FB80F91B159A7FA9F0C42A894BB8BCC5 org.osgi:osgi.core:5.0.0

--- a/libs.osgi/external/osgi-5.0-license.txt
+++ b/libs.osgi/external/osgi-5.0-license.txt
@@ -1,6 +1,6 @@
 Name: OSGi
 Version: 5.0
-Files: osgi.core-5.0.0.jar osgi.cmpn-4.2.jar
+Files: osgi.core-5.0.0.jar osgi.cmpn-4.2.jar org.osgi.compendium-4.2.0.jar
 Description: OSGi specification (core & compendium).
 License: Apache-2.0
 Origin: OSGi


### PR DESCRIPTION
Maven central does not hold the original netbeans artifact 
osgi.cmpn-4.2, but a superset of that: 

<dependency>
    <groupId>org.osgi</groupId>
    <artifactId>org.osgi.compendium</artifactId>
    <version>4.2.0</version>
</dependency>

That artifact holds not only the compiled binaries, but also the
java sources in a subfolder "OSGI-OPT". To get the original netbeans
file, the jar is repacked and the folder is stripped. The resulting
zip is not identical to the original binary, but the difference is
in the zip structure, after expanding the original contents and the
new file are identical.

This PR is a followup for #104 which introduced a maven coordinate,
that can't be satisfied from maven central.

There are newer osgi compendium jar on maven central and it looks
as if at least 4.3.1 would also work, but updating libraries should be
a separate task from this cleanup task.

This approach was inspired by @vieiro who first came up with
building modified binaries for maven sources.

@geertjanw could you please have a look at this and see if it works for you?