### PR TITLE
Using HTML/Java 1.5 release bits

### DIFF
--- a/net.java.html.boot.fx/external/binaries-list
+++ b/net.java.html.boot.fx/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-A5ECB6F58BB276CF77FD0E18A07656508E7099B6 org.netbeans.html:net.java.html.boot.fx:1.4
+88E4B752D0534161992A6C4992F620917F68EE81 org.netbeans.html:net.java.html.boot.fx:1.5

--- a/net.java.html.boot.fx/nbproject/project.properties
+++ b/net.java.html.boot.fx/nbproject/project.properties
@@ -14,6 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-release.external/net.java.html.boot.fx-1.4.jar=modules/net-java-html-boot-fx.jar
+release.external/net.java.html.boot.fx-1.5.jar=modules/net-java-html-boot-fx.jar
 is.autoload=true
 nbm.module.author=Jaroslav Tulach

--- a/net.java.html.boot.script/external/binaries-list
+++ b/net.java.html.boot.script/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-5CC4FD2D576DEEC4F64E46BAA9097525BA4DF8D8 org.netbeans.html:net.java.html.boot.script:1.4
+276009D3F0A27079A80D241C3183EC712305A42A org.netbeans.html:net.java.html.boot.script:1.5

--- a/net.java.html.boot.script/nbproject/project.properties
+++ b/net.java.html.boot.script/nbproject/project.properties
@@ -14,6 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-release.external/net.java.html.boot.script-1.4.jar=modules/net-java-html-boot-script.jar
+release.external/net.java.html.boot.script-1.5.jar=modules/net-java-html-boot-script.jar
 is.autoload=true
 nbm.module.author=Jaroslav Tulach

--- a/net.java.html.boot/external/binaries-list
+++ b/net.java.html.boot/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-DEABE58D6CDDD124BEA30E9B6E6BD48E90CD7AA1 org.netbeans.html:net.java.html.boot:1.4
+D58237D5C8DDC341550F79ADB8DD972FBA674598 org.netbeans.html:net.java.html.boot:1.5

--- a/net.java.html.boot/nbproject/project.properties
+++ b/net.java.html.boot/nbproject/project.properties
@@ -14,6 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-release.external/net.java.html.boot-1.4.jar=modules/net-java-html-boot.jar
+release.external/net.java.html.boot-1.5.jar=modules/net-java-html-boot.jar
 is.autoload=true
 nbm.module.author=Jaroslav Tulach

--- a/net.java.html.geo/external/binaries-list
+++ b/net.java.html.geo/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-0C735D28C3C2F22A9EB86A1F682AAC38920A6356 org.netbeans.html:net.java.html.geo:1.4
+2B229100D44B013A0770B773C969F116E6DE87FF org.netbeans.html:net.java.html.geo:1.5

--- a/net.java.html.geo/nbproject/project.properties
+++ b/net.java.html.geo/nbproject/project.properties
@@ -14,6 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-release.external/net.java.html.geo-1.4.jar=modules/net-java-html-geo.jar
+release.external/net.java.html.geo-1.5.jar=modules/net-java-html-geo.jar
 is.autoload=true
 nbm.module.author=Jaroslav Tulach

--- a/net.java.html.json/external/binaries-list
+++ b/net.java.html.json/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-CD15F35E44B6EC1CF8D7CC216870B70A71D88A1B org.netbeans.html:net.java.html.json:1.4
+756DBA6046CDBAA700B0B8D657E6ECB1C3E45929 org.netbeans.html:net.java.html.json:1.5

--- a/net.java.html.json/nbproject/project.properties
+++ b/net.java.html.json/nbproject/project.properties
@@ -14,6 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-release.external/net.java.html.json-1.4.jar=modules/net-java-html-json.jar
+release.external/net.java.html.json-1.5.jar=modules/net-java-html-json.jar
 is.autoload=true
 nbm.module.author=Jaroslav Tulach

--- a/net.java.html.sound/external/binaries-list
+++ b/net.java.html.sound/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-D7902EF2C6C94BE1F8804B5DDF2084A07DE87EFE org.netbeans.html:net.java.html.sound:1.4
+AC2C5DEAEE0A0C254CC4B9DA21DB96F24C950E7B org.netbeans.html:net.java.html.sound:1.5

--- a/net.java.html.sound/nbproject/project.properties
+++ b/net.java.html.sound/nbproject/project.properties
@@ -14,6 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-release.external/net.java.html.sound-1.4.jar=modules/net-java-html-sound.jar
+release.external/net.java.html.sound-1.5.jar=modules/net-java-html-sound.jar
 is.autoload=true
 nbm.module.author=Jaroslav Tulach

--- a/net.java.html/external/binaries-list
+++ b/net.java.html/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-F752490EC8F6CEC5B7E07947A1407CE8A8E63518 org.netbeans.html:net.java.html:1.4
+3D9614BD1DD5E4689D3A79711C1E5CEE6DB2A1E0 org.netbeans.html:net.java.html:1.5

--- a/net.java.html/nbproject/project.properties
+++ b/net.java.html/nbproject/project.properties
@@ -14,6 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-release.external/net.java.html-1.4.jar=modules/net-java-html.jar
+release.external/net.java.html-1.5.jar=modules/net-java-html.jar
 is.autoload=true
 nbm.module.author=Jaroslav Tulach

--- a/o.n.html.ko4j/external/binaries-list
+++ b/o.n.html.ko4j/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-03800C0C31FD6828EA7D3F245B3A7C00E221AA22 org.netbeans.html:ko4j:1.4
+954581FA55BBF0AEE1EDEE4B79483B2B31F0B5D7 org.netbeans.html:ko4j:1.5

--- a/o.n.html.ko4j/nbproject/project.properties
+++ b/o.n.html.ko4j/nbproject/project.properties
@@ -14,6 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-release.external/ko4j-1.4.jar=modules/org-netbeans-html-ko4j.jar
+release.external/ko4j-1.5.jar=modules/org-netbeans-html-ko4j.jar
 nbm.module.author=Jaroslav Tulach
 is.autoload=true

--- a/o.n.html.xhr4j/external/binaries-list
+++ b/o.n.html.xhr4j/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-BB25868BD6C724018FB0350688975EC3B53230EA org.netbeans.html:xhr4j:1.4
+FC6AA07867972711664EAD769B7F9214A80DB0E2 org.netbeans.html:xhr4j:1.5

--- a/o.n.html.xhr4j/nbproject/project.properties
+++ b/o.n.html.xhr4j/nbproject/project.properties
@@ -14,6 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-release.external/xhr4j-1.4.jar=modules/org-netbeans-html-xhr4j.jar
+release.external/xhr4j-1.5.jar=modules/org-netbeans-html-xhr4j.jar
 nbm.module.author=Jaroslav Tulach
 is.autoload=true


### PR DESCRIPTION
Updating the Maven co-ordinates of HTML/Java API to point to recently released 1.5 bits. The 1.5 bits are licensed under Apache license - e.g. NetBeans Platform will remove dependency on old `CDDL` version and replace it with proper Apache one.