### PR TITLE
[NETBEANS-54] Module Review swing.validation

### DIFF
--- a/swing.validation/arch.xml
+++ b/swing.validation/arch.xml
@@ -50,7 +50,7 @@
  <answer id="arch-overall">
   <p>
    Provides a framework for adding user input validation to existing Swing
-   panels very simply.  See <a href="http://kenai.com/projects/simplevalidation/pages/Home">the
+   panels very simply.  See <a href="https://github.com/timboudreau/simplevalidation/">the
    Simple Validation</a> project for details.
    </p>
    <p>
@@ -160,7 +160,7 @@
 -->
  <answer id="arch-where">
   The source code for the Simple Validation project is at
-  <a href="http://kenai.com/projects/simplevalidation/pages/Home">http://kenai.com/projects/simplevalidation/pages/Home</a>.
+  <a href="https://github.com/timboudreau/simplevalidation/">https://github.com/timboudreau/simplevalidation/</a>.
   The adapters for dialog descriptors and wizards are in the module.
  </answer>
 
@@ -317,7 +317,7 @@
 -->
  <answer id="dep-non-nb">
   <p>
-   http://kenai.com/projects/simplevalidation/pages/Home
+   https://github.com/timboudreau/simplevalidation/
   </p>
  </answer>
 

--- a/swing.validation/external/ValidationAPI-license.txt
+++ b/swing.validation/external/ValidationAPI-license.txt
@@ -3,6 +3,7 @@ Version: 331
 License: CDDL-GPL-2-CP
 OSR: 11316
 Origin: Oracle (https://svn.kenai.com/svn/simplevalidation~src/trunk@331)
+       (same as: https://github.com/timboudreau/simplevalidation/tree/b26b94cc001a41ab9138496b11e2ae256a159ffd)
 Comment:  Provides utilities for adding input validation to Swing forms quickly and easily
 
 COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0

--- a/swing.validation/nbproject/project.properties
+++ b/swing.validation/nbproject/project.properties
@@ -18,6 +18,6 @@ is.autoload=true
 javac.source=1.6
 javac.compilerargs=-Xlint -Xlint:-serial
 javadoc.arch=${basedir}/arch.xml
-nbm.homepage=http://kenai.com/projects/simplevalidation/
+nbm.homepage=https://github.com/timboudreau/simplevalidation/
 nbm.module.author=Tim Boudreau
 release.external/ValidationAPI.jar=modules/ext/ValidationAPI.jar


### PR DESCRIPTION
Project includes `ValidationAPI.jar` (CDDL licensed), originally hosted on Kenai, now GitHub.
Changed dead references to Kenai to their equivalent GitHub coordinates.

Note:  Even if the `ValidationAPI.jar`  file is using the `org.netbeans`  package namespace it is not part of the grant, as far as I can tell. Therefore it is still CDDL licensed.

Should anyone want to recreate the binary from source: The binary uses Kenai SVN commit no as the version number. Since the project was transferred to GitHub with full commit history, it is possible to find the equivalent point in time in GitHub, namely end-of-day Nov 17, 2011. The URL is noted in `ValidationAPI-license.txt` file.
