### PR TITLE
Module review project ant

### DIFF
--- a/openide.util/src/org/openide/util/EditableProperties.java
+++ b/openide.util/src/org/openide/util/EditableProperties.java
@@ -83,7 +83,9 @@ public final class EditableProperties extends AbstractMap<String,String> impleme
             for (Item _i : original.items) {
                 Item i = (Item) _i.clone();
                 items.add(i);
-                itemIndex.put(i.getKey(), i);
+                if(i.getKey() != null) {
+                    itemIndex.put(i.getKey(), i);
+                }
             }
         }
     }
@@ -832,7 +834,7 @@ public final class EditableProperties extends AbstractMap<String,String> impleme
         }
         
         public int size() {
-            return state.items.size();
+            return state.itemIndex.size();
         }
         
     }

--- a/openide.util/test/unit/src/org/openide/util/EditablePropertiesTest.java
+++ b/openide.util/test/unit/src/org/openide/util/EditablePropertiesTest.java
@@ -33,6 +33,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Properties;
 import org.netbeans.junit.NbTestCase;
 
@@ -357,6 +358,30 @@ public class EditablePropertiesTest extends NbTestCase {
         assertEquals("Reading and re-writing non-Latin chars in comments works", expected, getAsString(p));
     }
 
+    // Test consistency of size of the property list for different view of it
+    public void testConsistentSize() throws Exception {
+        EditableProperties testProperties = loadTestProperties();
+        // Enumerate entries manually
+        int count = 0;
+        for(Entry<String,String> entry: testProperties.entrySet()) {
+            count++;
+        }
+        assertEquals(testProperties.size(), count);
+        assertEquals(testProperties.size(), testProperties.entrySet().size());
+        assertEquals(testProperties.size(), testProperties.keySet().size());
+    }
+    
+    // This test ensures, that the copy constructor or EditableProperties.State
+    // does not introduce NULL keys. These NULL keys are observable from the
+    // outside by an increased number of elements.
+    public void testCopyWithIndependentComments() throws Exception {
+        EditableProperties testProperties = loadTestProperties();
+        EditableProperties test2Properties = testProperties.cloneProperties();
+        int originalSize = testProperties.size();
+        assertTrue(testProperties.containsKey("key1"));
+        testProperties.setProperty("key1", "XXX");
+        assertEquals(originalSize, testProperties.size());
+    }
     
     // helper methods:
     

--- a/project.ant/test/unit/src/org/netbeans/spi/project/support/ant/data/build-impl.xsl
+++ b/project.ant/test/unit/src/org/netbeans/spi/project/support/ant/data/build-impl.xsl
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <xsl:stylesheet version="1.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:p="http://www.netbeans.org/ns/project/1"

--- a/project.ant/test/unit/src/org/netbeans/spi/project/support/ant/data/build.xsl
+++ b/project.ant/test/unit/src/org/netbeans/spi/project/support/ant/data/build.xsl
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <xsl:stylesheet version="1.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:project="http://www.netbeans.org/ns/project/1"

--- a/project.ant/test/unit/src/org/netbeans/spi/project/support/ant/data/build2.xsl
+++ b/project.ant/test/unit/src/org/netbeans/spi/project/support/ant/data/build2.xsl
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <xsl:stylesheet version="1.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:project="http://www.netbeans.org/ns/project/1"

--- a/project.ant/test/unit/src/org/netbeans/spi/project/support/ant/data/extension1.xml
+++ b/project.ant/test/unit/src/org/netbeans/spi/project/support/ant/data/extension1.xml
@@ -1,5 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
 
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <!--
     Document   : extension1.xml.xml
     Created on : March 28, 2007, 3:56 PM

--- a/project.ant/test/unit/src/org/netbeans/spi/project/support/ant/data/global.properties
+++ b/project.ant/test/unit/src/org/netbeans/spi/project/support/ant/data/global.properties
@@ -1,1 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 global.prop=value5

--- a/project.ant/test/unit/src/org/netbeans/spi/project/support/ant/data/private.properties
+++ b/project.ant/test/unit/src/org/netbeans/spi/project/support/ant/data/private.properties
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 private.prop=value2
 overridden.prop=value4
 tempdir=${java.io.tmpdir}/foo

--- a/project.ant/test/unit/src/org/netbeans/spi/project/support/ant/data/private.xml
+++ b/project.ant/test/unit/src/org/netbeans/spi/project/support/ant/data/private.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <project-private xmlns="http://www.netbeans.org/ns/project-private/1">
     <data xmlns="urn:test:private">
         <private-stuff/>

--- a/project.ant/test/unit/src/org/netbeans/spi/project/support/ant/data/project-modified.xml
+++ b/project.ant/test/unit/src/org/netbeans/spi/project/support/ant/data/project-modified.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <project xmlns="http://www.netbeans.org/ns/project/1">
     <type>test</type>
     <configuration>


### PR DESCRIPTION
The first commit updates the file in project.ant with the correct
license headers. There are two main changesets:

- the first changeset adds the headers
- the second changeset fixes the failing unittests in project.ant which
  show a problem in openide.util.