### PR TITLE
Multiple maven repository support 

### DIFF
--- a/nbbuild/default-properties.xml
+++ b/nbbuild/default-properties.xml
@@ -68,6 +68,8 @@
   
   <property name="binaries.cache" location="${user.home}/.hgexternalcache"/>
   <property name="binaries.server" value="http://hg.netbeans.org/binaries/"/>
+  <!-- A space separated, sorted list of alternate repositories used to download artifacts when not found in Maven central -->
+  <property name="binaries.repositories" value="https://repo.eclipse.org/service/local/repositories/acceleo-releases/content/" />
 
   <target name="-load-build-properties">
     <property file="${nb_all}/nbbuild/build.properties"/>

--- a/netbinox/external/binaries-list
+++ b/netbinox/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-E5DDC5E827D3D62E7BE9F7E32927CA01F2839971 org.eclipse.osgi_3.9.1.v20140110-1610.jar
+4499D6104182D349F0EC59D6D166123AA5F09174 org.eclipse.core:org.eclipse.osgi:3.9.1.v20140110-1610

--- a/netbinox/nbproject/project.properties
+++ b/netbinox/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 is.autoload=true
-release.external/org.eclipse.osgi_3.9.1.v20140110-1610.jar=modules/ext/org.eclipse.osgi_3.9.1.v20140110-1610.jar
+release.external/org.eclipse.osgi-3.9.1.v20140110-1610.jar=modules/ext/org.eclipse.osgi_3.9.1.v20140110-1610.jar
 javac.source=1.6
 javac.target=1.7
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/netbinox/nbproject/project.xml
+++ b/netbinox/nbproject/project.xml
@@ -123,7 +123,7 @@
             </public-packages>
             <class-path-extension>
                 <runtime-relative-path>ext/org.eclipse.osgi_3.9.1.v20140110-1610.jar</runtime-relative-path>
-                <binary-origin>external/org.eclipse.osgi_3.9.1.v20140110-1610.jar</binary-origin>
+                <binary-origin>external/org.eclipse.osgi-3.9.1.v20140110-1610.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>


### PR DESCRIPTION
	- Modified DownloadBinaries.java to use an eclipse// prefix in a maven coordinate.
	- Added a maven coordinate to the netbinox module.

This PR is currently experimental, just for review.