### PR TITLE
[NETBEANS-54] Module Review o.n.upgrader

### DIFF
--- a/o.n.upgrader/src/org/netbeans/upgrade/systemoptions/systemoptionsimport
+++ b/o.n.upgrader/src/org/netbeans/upgrade/systemoptions/systemoptionsimport
@@ -1,3 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 Services/org-netbeans-core-IDESettings.settings
 Services/org-netbeans-modules-derby-DerbyOptions.settings
 Services/org-apache-tools-ant-module-AntSettings.settings


### PR DESCRIPTION
Add the license header to systemoptionsimport.

This file is used in `o.n.upgrader/src/org/netbeans/upgrade/systemoptions/Importer.java` (see the following). I think that it can be added the license header because it is used as a properties file. 

https://github.com/apache/incubator-netbeans/blob/7fd9f79a84d02b6122a4089b9b65fc7f8ca3dcb7/o.n.upgrader/src/org/netbeans/upgrade/systemoptions/Importer.java#L33

https://github.com/apache/incubator-netbeans/blob/7fd9f79a84d02b6122a4089b9b65fc7f8ca3dcb7/o.n.upgrader/src/org/netbeans/upgrade/systemoptions/Importer.java#L85-L94