### PR TITLE
Disabling check for maven coordinates in RatReportTask.

### DIFF
--- a/nbbuild/antsrc/org/netbeans/nbbuild/RatReportTask.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/RatReportTask.java
@@ -166,7 +166,6 @@ public class RatReportTask extends Task {
         } catch (ParserConfigurationException | SAXException | IOException | XPathExpressionException ex) {
             throw new BuildException("Cannot parse Rat report ", ex);
         }
-        doCheckExternal(moduleRATInfo);
 
         for (String clusterName : clusterList) {
             // create a report file by cluster
@@ -234,35 +233,6 @@ public class RatReportTask extends Task {
                 moduleRATInfo.get(moduleName).addApproved(resources);
             }
 
-        }
-    }
-
-    private void doCheckExternal(Map<String, ModuleInfo> moduleRATInfo) {
-        for (Map.Entry<String, ModuleInfo> minfo : moduleRATInfo.entrySet()) {
-            File binaryList = new File(minfo.getValue().getFolder(), File.separator + "external" + File.separator + "binaries-list");
-            if (binaryList.exists()) {
-                try (BufferedReader br = new BufferedReader(new FileReader(binaryList))) {
-                    String line = br.readLine();
-                    while (line != null) {
-                        if (line.trim().startsWith("#") || line.trim().isEmpty()) {
-                            // comment
-                        } else {
-                            String[] splitedExternalInfo = line.split(" ");
-
-                            String[] mavenizedExternal = splitedExternalInfo[1].split(":");
-                            if (mavenizedExternal.length != 3) {
-                                minfo.getValue().addInvalidExternal(splitedExternalInfo[1]);
-                            }
-                        }
-                        line = br.readLine();
-                    }
-                } catch (FileNotFoundException ex) {
-                    Logger.getLogger(RatReportTask.class.getName()).log(Level.SEVERE, null, ex);
-                } catch (IOException ex) {
-                    Logger.getLogger(RatReportTask.class.getName()).log(Level.SEVERE, null, ex);
-                }
-
-            }
         }
     }
 


### PR DESCRIPTION
The RatReportTask is checking that external binaries are downloaded using maven coordinates. While In principle that check is not bad, I'd like to remove it. There's a couple reasons for that:
1. I don't think it is a hard-error at this time to download binaries not using maven coordinates.
2. we have the ant verify-libs-and-licenses working again (for platform at least). This is checking consistency between the license files, binaries and nbbuild/licenses. If at some point it should become a hard error to not download from maven, then verify-libs-and-licenses seems like a better place to do the check.
3. I think it would be cleaner if RatReportTask would just convert the rat report to junit test files, and not do any checks itself.

The main driving force behind this patch is that I am trying to set-up a "release" job (a job that produced release artefacts), and I'd like it to run Rat and verify-libs-and-licenses and when the build is passing/blue, we could try to release. And I don't think it is realistic to only use maven coordinates in near enough future.