### PR TITLE
Adjusting header in libs.osgi/external/osgi-5.0-license.txt, org.osgi…

### DIFF
--- a/libs.osgi/external/osgi-5.0-license.txt
+++ b/libs.osgi/external/osgi-5.0-license.txt
@@ -1,6 +1,6 @@
 Name: OSGi
 Version: 5.0
-Files: osgi.core-5.0.0.jar osgi.cmpn-4.2.jar org.osgi.compendium-4.2.0.jar
+Files: osgi.core-5.0.0.jar org.osgi.compendium-4.2.0.jar
 Description: OSGi specification (core & compendium).
 License: Apache-2.0
 Origin: OSGi


### PR DESCRIPTION
….compendium-4.2.0.jar is used now, not osgi.cmpn-4.2.jar.