### PR TITLE
 [NETBEANS-54] Module Review o.eclipse.core.runtime

### DIFF
--- a/o.eclipse.core.runtime/external/binaries-list
+++ b/o.eclipse.core.runtime/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-D2D2105B1E3C9E2FA6240AD088237A57590DDA8D org.eclipse.core.runtime-3.7.0_nosignature.jar
+6658C235056134F7E86295E751129508802D71F2 org.eclipse.core:org.eclipse.core.runtime:3.7.0

--- a/o.eclipse.core.runtime/nbproject/project.properties
+++ b/o.eclipse.core.runtime/nbproject/project.properties
@@ -14,6 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-release.external/org.eclipse.core.runtime-3.7.0_nosignature.jar=modules/org-eclipse-core-runtime.jar
+release.external/org.eclipse.core.runtime-3.7.0.jar=modules/org-eclipse-core-runtime.jar
 is.autoload=true
 nbm.module.author=Tomas Stupka

--- a/o.eclipse.core.runtime/nbproject/project.xml
+++ b/o.eclipse.core.runtime/nbproject/project.xml
@@ -76,7 +76,7 @@
             </public-packages>
             <class-path-extension>
                 <runtime-relative-path>org-eclipse-core-runtime.jar</runtime-relative-path>
-                <binary-origin>external/org.eclipse.core.runtime-3.7.0_nosignature.jar</binary-origin>
+                <binary-origin>external/org.eclipse.core.runtime-3.7.0.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>


### PR DESCRIPTION
 - Added maven coordinates for the binary. 
 - No other licensing issues found (but for manifest.mf, to be handled centrally).