### PR TITLE
[NETBEANS-112] Re-integrate DTD for RSS 0.91 feed

### DIFF
--- a/nbbuild/build.xml
+++ b/nbbuild/build.xml
@@ -2057,6 +2057,7 @@ It is possible to use -Ddebug.port=3234 -Ddebug.pause=y to start the system in d
             <exclude name="websvc.saas.api/test/unit/src/org/netbeans/modules/websvc/saas/model/application.wadl" /> <!--test data-->
             <exclude name="websvc.saas.api/test/unit/src/org/netbeans/modules/websvc/saas/util/rootGroup.xml" /> <!--test data-->
             <exclude name="websvc.saas.kit/release/VERSION.txt" /> <!--generated file-->
+            <exclude name="welcome/src/org/netbeans/modules/welcome/resources/rss-0_91.dtd" /> <!-- specifies a standard -->
             <exclude name="xml.axi/test/unit/src/org/netbeans/modules/xml/axi/resources/**" /> <!-- test data -->
             <exclude name="xml.lexer/test/unit/src/org/netbeans/api/xml/lexer/resources/*.dtd" /> <!-- test data -->
             <exclude name="xml.lexer/test/unit/src/org/netbeans/api/xml/lexer/resources/*.xml" /> <!-- test data -->

--- a/welcome/src/org/netbeans/modules/welcome/resources/layer.xml
+++ b/welcome/src/org/netbeans/modules/welcome/resources/layer.xml
@@ -95,14 +95,14 @@
         public IDs to filesystem constructs (files and folders).
         -->
 
-<!--        <folder name="entities">
+        <folder name="entities">
             <folder name="Netscape_Communications">
                 <file name="DTD_RSS_0_91" url="rss-0_91.dtd">
                     <attr name="hint.originalPublicID" stringvalue="-//Netscape Communications//DTD RSS 0.91//EN"/>
                 </file>
             </folder>
 
-        </folder>-->
+        </folder>
 
 
     </folder>

--- a/welcome/src/org/netbeans/modules/welcome/resources/rss-0_91.dtd
+++ b/welcome/src/org/netbeans/modules/welcome/resources/rss-0_91.dtd
@@ -1,0 +1,175 @@
+<!--  
+  Downloaded from http://www.rssboard.org/rss-0.91.dtd
+  by Apache NetBeans project, 2017-11-04.
+-->
+<!--
+
+  Rich Site Summary (RSS) 0.91 official DTD, proposed.
+  
+  RSS is an XML vocabulary for describing
+  metadata about websites, and enabling the display of
+  "channels" on the "My Netscape" website.
+  
+  RSS Info can be found at http://channel.netscape.com/publish/
+  XML Info can be found at http://www.w3.org/XML/ 
+  
+  copyright Netscape Communications, 1999
+
+  Dan Libby - danda@netscape.com
+  
+  Based on RSS DTD originally created by
+  Lars Marius Garshol - larsga@ifi.uio.no.
+  $Id: rss-0.91.dtd,v 1.2 2001/04/26 03:02:34 eedrin Exp $
+  
+-->
+
+<!ELEMENT rss (channel)>
+<!ATTLIST rss
+          version     CDATA #REQUIRED> <!-- must be "0.91"> -->
+
+<!ELEMENT channel (title | description | link | language | item+ | rating? | image? | textinput? | copyright? | pubDate? | lastBuildDate? | docs? | managingEditor? | webMaster? | skipHours? | skipDays?)*>
+<!ELEMENT title (#PCDATA)>
+<!ELEMENT description (#PCDATA)>
+<!ELEMENT link (#PCDATA)>
+<!ELEMENT image (title | url | link | width? | height? | description?)*>
+<!ELEMENT url (#PCDATA)>
+<!ELEMENT item (title | link | description)*>
+<!ELEMENT textinput (title | description | name | link)*>
+<!ELEMENT name (#PCDATA)>
+<!ELEMENT rating (#PCDATA)>
+<!ELEMENT language (#PCDATA)>
+<!ELEMENT width (#PCDATA)>
+<!ELEMENT height (#PCDATA)>
+<!ELEMENT copyright (#PCDATA)>
+<!ELEMENT pubDate (#PCDATA)>
+<!ELEMENT lastBuildDate (#PCDATA)>
+<!ELEMENT docs (#PCDATA)>
+<!ELEMENT managingEditor (#PCDATA)>
+<!ELEMENT webMaster (#PCDATA)>
+<!ELEMENT hour (#PCDATA)>
+<!ELEMENT day (#PCDATA)>
+<!ELEMENT skipHours (hour+)>
+<!ELEMENT skipDays (day+)>
+
+<!--
+     Copied from HTML 3.2 DTD, with modifications (removed CDATA)
+     http://www.w3.org/TR/REC-html32.html#dtd
+     =============== BEGIN ===================
+-->
+<!-- 
+     Character Entities for ISO Latin-1
+     
+     (C) International Organization for Standardization 1986
+     Permission to copy in any form is granted for use with
+     conforming SGML systems and applications as defined in
+     ISO 8879, provided this notice is included in all copies.
+     This has been extended for use with HTML to cover the full
+     set of codes in the range 160-255 decimal.
+-->
+<!-- Character entity set. Typical invocation:
+     <!ENTITY % ISOlat1 PUBLIC
+       "ISO 8879-1986//ENTITIES Added Latin 1//EN//HTML">
+     %ISOlat1;
+-->
+    <!ENTITY nbsp   "&#160;"> <!-- no-break space -->
+    <!ENTITY iexcl  "&#161;"> <!-- inverted exclamation mark -->
+    <!ENTITY cent   "&#162;"> <!-- cent sign -->
+    <!ENTITY pound  "&#163;"> <!-- pound sterling sign -->
+    <!ENTITY curren "&#164;"> <!-- general currency sign -->
+    <!ENTITY yen    "&#165;"> <!-- yen sign -->
+    <!ENTITY brvbar "&#166;"> <!-- broken (vertical) bar -->
+    <!ENTITY sect   "&#167;"> <!-- section sign -->
+    <!ENTITY uml    "&#168;"> <!-- umlaut (dieresis) -->
+    <!ENTITY copy   "&#169;"> <!-- copyright sign -->
+    <!ENTITY ordf   "&#170;"> <!-- ordinal indicator, feminine -->
+    <!ENTITY laquo  "&#171;"> <!-- angle quotation mark, left -->
+    <!ENTITY not    "&#172;"> <!-- not sign -->
+    <!ENTITY shy    "&#173;"> <!-- soft hyphen -->
+    <!ENTITY reg    "&#174;"> <!-- registered sign -->
+    <!ENTITY macr   "&#175;"> <!-- macron -->
+    <!ENTITY deg    "&#176;"> <!-- degree sign -->
+    <!ENTITY plusmn "&#177;"> <!-- plus-or-minus sign -->
+    <!ENTITY sup2   "&#178;"> <!-- superscript two -->
+    <!ENTITY sup3   "&#179;"> <!-- superscript three -->
+    <!ENTITY acute  "&#180;"> <!-- acute accent -->
+    <!ENTITY micro  "&#181;"> <!-- micro sign -->
+    <!ENTITY para   "&#182;"> <!-- pilcrow (paragraph sign) -->
+    <!ENTITY middot "&#183;"> <!-- middle dot -->
+    <!ENTITY cedil  "&#184;"> <!-- cedilla -->
+    <!ENTITY sup1   "&#185;"> <!-- superscript one -->
+    <!ENTITY ordm   "&#186;"> <!-- ordinal indicator, masculine -->
+    <!ENTITY raquo  "&#187;"> <!-- angle quotation mark, right -->
+    <!ENTITY frac14 "&#188;"> <!-- fraction one-quarter -->
+    <!ENTITY frac12 "&#189;"> <!-- fraction one-half -->
+    <!ENTITY frac34 "&#190;"> <!-- fraction three-quarters -->
+    <!ENTITY iquest "&#191;"> <!-- inverted question mark -->
+    <!ENTITY Agrave "&#192;"> <!-- capital A, grave accent -->
+    <!ENTITY Aacute "&#193;"> <!-- capital A, acute accent -->
+    <!ENTITY Acirc  "&#194;"> <!-- capital A, circumflex accent -->
+    <!ENTITY Atilde "&#195;"> <!-- capital A, tilde -->
+    <!ENTITY Auml   "&#196;"> <!-- capital A, dieresis or umlaut mark -->
+    <!ENTITY Aring  "&#197;"> <!-- capital A, ring -->
+    <!ENTITY AElig  "&#198;"> <!-- capital AE diphthong (ligature) -->
+    <!ENTITY Ccedil "&#199;"> <!-- capital C, cedilla -->
+    <!ENTITY Egrave "&#200;"> <!-- capital E, grave accent -->
+    <!ENTITY Eacute "&#201;"> <!-- capital E, acute accent -->
+    <!ENTITY Ecirc  "&#202;"> <!-- capital E, circumflex accent -->
+    <!ENTITY Euml   "&#203;"> <!-- capital E, dieresis or umlaut mark -->
+    <!ENTITY Igrave "&#204;"> <!-- capital I, grave accent -->
+    <!ENTITY Iacute "&#205;"> <!-- capital I, acute accent -->
+    <!ENTITY Icirc  "&#206;"> <!-- capital I, circumflex accent -->
+    <!ENTITY Iuml   "&#207;"> <!-- capital I, dieresis or umlaut mark -->
+    <!ENTITY ETH    "&#208;"> <!-- capital Eth, Icelandic -->
+    <!ENTITY Ntilde "&#209;"> <!-- capital N, tilde -->
+    <!ENTITY Ograve "&#210;"> <!-- capital O, grave accent -->
+    <!ENTITY Oacute "&#211;"> <!-- capital O, acute accent -->
+    <!ENTITY Ocirc  "&#212;"> <!-- capital O, circumflex accent -->
+    <!ENTITY Otilde "&#213;"> <!-- capital O, tilde -->
+    <!ENTITY Ouml   "&#214;"> <!-- capital O, dieresis or umlaut mark -->
+    <!ENTITY times  "&#215;"> <!-- multiply sign -->
+    <!ENTITY Oslash "&#216;"> <!-- capital O, slash -->
+    <!ENTITY Ugrave "&#217;"> <!-- capital U, grave accent -->
+    <!ENTITY Uacute "&#218;"> <!-- capital U, acute accent -->
+    <!ENTITY Ucirc  "&#219;"> <!-- capital U, circumflex accent -->
+    <!ENTITY Uuml   "&#220;"> <!-- capital U, dieresis or umlaut mark -->
+    <!ENTITY Yacute "&#221;"> <!-- capital Y, acute accent -->
+    <!ENTITY THORN  "&#222;"> <!-- capital THORN, Icelandic -->
+    <!ENTITY szlig  "&#223;"> <!-- small sharp s, German (sz ligature) -->
+    <!ENTITY agrave "&#224;"> <!-- small a, grave accent -->
+    <!ENTITY aacute "&#225;"> <!-- small a, acute accent -->
+    <!ENTITY acirc  "&#226;"> <!-- small a, circumflex accent -->
+    <!ENTITY atilde "&#227;"> <!-- small a, tilde -->
+    <!ENTITY auml   "&#228;"> <!-- small a, dieresis or umlaut mark -->
+    <!ENTITY aring  "&#229;"> <!-- small a, ring -->
+    <!ENTITY aelig  "&#230;"> <!-- small ae diphthong (ligature) -->
+    <!ENTITY ccedil "&#231;"> <!-- small c, cedilla -->
+    <!ENTITY egrave "&#232;"> <!-- small e, grave accent -->
+    <!ENTITY eacute "&#233;"> <!-- small e, acute accent -->
+    <!ENTITY ecirc  "&#234;"> <!-- small e, circumflex accent -->
+    <!ENTITY euml   "&#235;"> <!-- small e, dieresis or umlaut mark -->
+    <!ENTITY igrave "&#236;"> <!-- small i, grave accent -->
+    <!ENTITY iacute "&#237;"> <!-- small i, acute accent -->
+    <!ENTITY icirc  "&#238;"> <!-- small i, circumflex accent -->
+    <!ENTITY iuml   "&#239;"> <!-- small i, dieresis or umlaut mark -->
+    <!ENTITY eth    "&#240;"> <!-- small eth, Icelandic -->
+    <!ENTITY ntilde "&#241;"> <!-- small n, tilde -->
+    <!ENTITY ograve "&#242;"> <!-- small o, grave accent -->
+    <!ENTITY oacute "&#243;"> <!-- small o, acute accent -->
+    <!ENTITY ocirc  "&#244;"> <!-- small o, circumflex accent -->
+    <!ENTITY otilde "&#245;"> <!-- small o, tilde -->
+    <!ENTITY ouml   "&#246;"> <!-- small o, dieresis or umlaut mark -->
+    <!ENTITY divide "&#247;"> <!-- divide sign -->
+    <!ENTITY oslash "&#248;"> <!-- small o, slash -->
+    <!ENTITY ugrave "&#249;"> <!-- small u, grave accent -->
+    <!ENTITY uacute "&#250;"> <!-- small u, acute accent -->
+    <!ENTITY ucirc  "&#251;"> <!-- small u, circumflex accent -->
+    <!ENTITY uuml   "&#252;"> <!-- small u, dieresis or umlaut mark -->
+    <!ENTITY yacute "&#253;"> <!-- small y, acute accent -->
+    <!ENTITY thorn  "&#254;"> <!-- small thorn, Icelandic -->
+    <!ENTITY yuml   "&#255;"> <!-- small y, dieresis or umlaut mark -->
+    
+<!--
+     Copied from HTML 3.2 DTD, with modifications (removed CDATA)
+     http://www.w3.org/TR/REC-html32.html#dtd
+     ================= END ===================
+-->


### PR DESCRIPTION
This change undoes the removal of the DTD file done by Oracle as preparation for the donation. The change fixes NETBEANS-112.

It is assumed that Oracle removed the file from the donation as it wasn't theirs to donate.
See:
http://hg.netbeans.org/releases/rev/66633aaa2811
http://hg.netbeans.org/releases/rev/00ff3249694f


**About license for DTD file:**
Netscape transferred the RSS 0.91 specification to the RSS Advisory Board in January 2008. From their website I cannot figure out what the license is for the 0.91 DTD file, but newer versions of the RSS spec seem to be published under the _Creative Commons Attribution/Share Alike 2.0_ license. However, this conclusion cannot be made for the 0.91 spec. No license header has thus been added to the DTD file, only a note about from where it has been downloaded.

Instead it is assumed, that the DTD file fall under the

https://www.apache.org/legal/resolved.html#category-b

definition of:

> For small amounts of source that is directly consumed by the ASF product
> at runtime in source form, and for which that source is unmodified and
> unlikely to be changed anyway (say, by virtue of being specified by a
> standard), inclusion of appropriately labeled source is also permitted.
> An example of this is the web-facesconfig_1_0.dtd, whose inclusion is
> mandated by the JSR 127: JavaServer Faces specification.