### PR TITLE
Ensuring license texts are read using UTF-8 encoding.

### DIFF
--- a/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/VerifyLibsAndLicenses.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/VerifyLibsAndLicenses.java
@@ -299,7 +299,7 @@ public class VerifyLibsAndLicenses extends Task {
                         StringBuffer masterBody = new StringBuffer();
                         is = new FileInputStream(licenseFile);
                         try {
-                            BufferedReader r = new BufferedReader(new InputStreamReader(is));
+                            BufferedReader r = new BufferedReader(new InputStreamReader(is, "UTF-8"));
                             int c;
                             while ((c = r.read()) != -1) {
                                 masterBody.append((char) c);


### PR DESCRIPTION
Hopefully will avoid false reports in verify-libs-and-licenses when the default encoding is not UTF-8.