### PR TITLE
Not copying the JavaHelp library into the binary.

### DIFF
--- a/javahelp/external/jhall-2.0_05-license.txt
+++ b/javahelp/external/jhall-2.0_05-license.txt
@@ -5,6 +5,7 @@ Source: https://javahelp.dev.java.net/files/documents/5985/59373/javahelp2-src-2
 Description: Standard Java help browser system.
 Origin: Oracle
 URL: http://download.java.net/javadesktop/javahelp/javahelp2_0_05.zip
+Type: compile-time
 
 The GNU General Public License (GPL)
 Version 2, June 1991

--- a/javahelp/manifest.mf
+++ b/javahelp/manifest.mf
@@ -6,5 +6,4 @@ OpenIDE-Module-Provides: org.netbeans.api.javahelp.Help
 OpenIDE-Module-Requires: org.openide.modules.InstalledFileLocator, org.openide.modules.ModuleFormat2
 OpenIDE-Module-Layer: org/netbeans/modules/javahelp/resources/layer.xml
 OpenIDE-Module-Install: org/netbeans/modules/javahelp/Installer.class
-OpenIDE-Module-Hide-Classpath-Packages: javax.help.**, com.sun.java.help.**
 

--- a/javahelp/nbproject/project.properties
+++ b/javahelp/nbproject/project.properties
@@ -16,7 +16,6 @@
 # under the License.
 
 is.autoload=true
-release.external/jhall-2.0_05.jar=modules/ext/jhall-2.0_05.jar
 
 javac.compilerargs=-Xlint:unchecked
 javac.source=1.6

--- a/javahelp/nbproject/project.xml
+++ b/javahelp/nbproject/project.xml
@@ -178,10 +178,9 @@
             </test-dependencies>
             <public-packages>
                 <package>org.netbeans.api.javahelp</package>
-                <subpackages>javax.help</subpackages>
             </public-packages>
             <class-path-extension>
-                <runtime-relative-path>ext/jhall-2.0_05.jar</runtime-relative-path>
+                <runtime-relative-path/>
                 <binary-origin>external/jhall-2.0_05.jar</binary-origin>
             </class-path-extension>
         </data>

--- a/javahelp/src/org/netbeans/modules/javahelp/HelpCtxProcessor.java
+++ b/javahelp/src/org/netbeans/modules/javahelp/HelpCtxProcessor.java
@@ -64,6 +64,12 @@ public final class HelpCtxProcessor implements Environment.Provider {
     }
     
     public @Override Lookup getEnvironment(final DataObject obj) {
+        try {
+            Class.forName("javax.help.HelpSet");
+        } catch (ClassNotFoundException ex) {
+            //JavaHelp not available, ignore:
+            return Lookup.EMPTY;
+        }
         Installer.log.log(Level.FINE, "creating help context presenter from {0}", obj.getPrimaryFile());
         return Lookups.singleton(new InstanceCookie() {
             private Action instance = null;

--- a/javahelp/src/org/netbeans/modules/javahelp/HelpSetProcessor.java
+++ b/javahelp/src/org/netbeans/modules/javahelp/HelpSetProcessor.java
@@ -54,6 +54,12 @@ public final class HelpSetProcessor implements Environment.Provider {
     private static final String HELPSET_MERGE_ATTR = "mergeIntoMaster"; // NOI18N
     
     public @Override Lookup getEnvironment(final DataObject obj) {
+        try {
+            Class.forName("javax.help.HelpSet");
+        } catch (ClassNotFoundException ex) {
+            //JavaHelp not available, ignore:
+            return Lookup.EMPTY;
+        }
         Installer.log.log(Level.FINE, "creating help set from ref: {0}", obj.getPrimaryFile());
         return Lookups.singleton(new InstanceCookie() {
             public @Override String instanceName() {


### PR DESCRIPTION
This avoids the runtime dependency on JavaHelp (compile-time dependency remains). Help is not working as a result. Can be partially workarounded by saying:
--cp:a <path-to-jhall.jar>
on command line, but there are still bugs with that (as JavaHelp is loaded by a classloader that does not see NetBeans classes).