### PR TITLE
[NETBEANS-68] Fix NULL handling after fix in 1d362fa77521762a9af99792620414086b868f76

### DIFF
--- a/db.dataview/src/org/netbeans/modules/db/dataview/table/ResultSetJXTable.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/table/ResultSetJXTable.java
@@ -170,7 +170,7 @@ public class ResultSetJXTable extends JXTableDecorator {
         setDefaultRenderer(Object.class, new ResultSetCellRenderer());
         setDefaultRenderer(String.class, new ResultSetCellRenderer());
         setDefaultRenderer(Number.class, new ResultSetCellRenderer());
-        setDefaultRenderer(Boolean.class, new BooleanCellRenderer());
+        setDefaultRenderer(Boolean.class, new ResultSetCellRenderer());
         setDefaultRenderer(java.sql.Date.class, new ResultSetCellRenderer(ResultSetCellRenderer.Date_TO_STRING));
         setDefaultRenderer(java.sql.Time.class, new ResultSetCellRenderer(ResultSetCellRenderer.TIME_TO_STRING));
         setDefaultRenderer(java.sql.Timestamp.class, new ResultSetCellRenderer(ResultSetCellRenderer.DATETIME_TO_STRING));

--- a/db.dataview/src/org/netbeans/modules/db/dataview/table/ResultSetTableCellEditor.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/table/ResultSetTableCellEditor.java
@@ -91,7 +91,7 @@ public class ResultSetTableCellEditor extends DefaultCellEditor {
             @Override
             public void setValue(Object value) {
                 val = value;
-                checkBox.setSelected((value != null) ? ((Boolean) value) : false);
+                checkBox.setSelected((value instanceof Boolean) ? ((Boolean) value) : false);
             }
 
             @Override


### PR DESCRIPTION
There are two issues:

- the BooleanCellRenderer used in the ResultSetJXTable should not be used
  directly, but only via the ResultSetCellRenderer. The ResultSetCellRenderer
  adds special handling to correctly show NULL values (and so protects the
  BooleanCellRenderer from NULL values)

- The ResultSetTableCellEditor assumes, that if the input element is a
  JCheckBox, the value is either NULL or a Boolean. This is not correct,
  as empty string can be come in as a default value.

  The solution is to check the type of the value only if the value is
  a Boolean, it is used to set the current value.

The issue was introduced in #234 