### PR TITLE
[NETBEANS-128] Not adding IDE launchers when building only the platfo…

### DIFF
--- a/nbbuild/build.xml
+++ b/nbbuild/build.xml
@@ -288,8 +288,18 @@
   <!-- Use of nbmerge target has the effect of automatically depending on all-X for every module. -->
   <!-- It also runs deltree(dir=wherever) and copydir(src=../X/netbeans,dest=wherever) to create the IDE install. -->
 
-  <target name="build-nozip" depends="init,download-selected-extbins,clean-cluster-flags,build-clusters,create-mandatory-files-for-binary,create-netbeans-import,finish-build,add-junit" description="Build the IDE but do not create a final ZIP file."/>
-  <target name="finish-build" depends="init">
+  <target name="build-nozip" depends="init,download-selected-extbins,clean-cluster-flags,build-clusters,create-mandatory-files-for-binary,create-netbeans-import,finish-build-platform,finish-build-nb,add-junit" description="Build the IDE but do not create a final ZIP file."/>
+  <target name="-check-nb-cluster" depends="init">
+       <condition property="has.nb.cluster">
+           <contains string="${nb.clusters.list}" substring="nb.cluster.nb" />
+       </condition>
+  </target>
+  <target name="finish-build-platform" depends="init,-check-nb-cluster" unless="has.nb.cluster">
+    <fixcrlf eol="lf" srcdir="${netbeans.dest.dir}" >
+      <include name="${nb.cluster.platform.dir}/lib/nbexec" />
+    </fixcrlf>
+  </target>
+  <target name="finish-build-nb" depends="init,-check-nb-cluster" if="has.nb.cluster">
     <loadproperties srcFile="${clusters.list.file}" />
 
     <downloadbinaries cache="${binaries.cache}" server="${binaries.server}">
@@ -310,8 +320,8 @@
     <fixcrlf eol="lf" srcdir="${netbeans.dest.dir}" >
       <include name="etc/netbeans.conf" />
       <include name="etc/netbeans.clusters" />
-      <include name="bin/netbeans" />      
-      <include name="${nb.cluster.platform.dir}/lib/nbexec" />      
+      <include name="bin/netbeans" />
+      <include name="${nb.cluster.platform.dir}/lib/nbexec" />
     </fixcrlf>
     <mkdir dir="${nb.build.dir}"/>
     <hgid property="hg.id" file=".."/>
@@ -991,10 +1001,13 @@ It is possible to use -Ddebug.port=3234 -Ddebug.pause=y to start the system in d
     <!-- architecture of jvm on which app will run -->
     <condition property="jvm.arch.string" value="64" else="">
       <available file="${nbjdk.home}\jre\lib\amd64" />
-    </condition>        
-    
+    </condition>
+
+    <condition property="tryme.launcher.prefix" value="${netbeans.dest.dir}/bin/netbeans" else="${netbeans.dest.dir}/platform/lib/nbexec">
+      <available file="${netbeans.dest.dir}/nb/.lastModified" />
+    </condition>
     <property name="run.args.ide" value=""/>
-    <exec osfamily="windows" executable="${netbeans.dest.dir}/bin/netbeans${jvm.arch.string}.exe" failonerror="yes" dir="${java.io.tmpdir}">
+    <exec osfamily="windows" executable="${tryme.launcher.prefix}${jvm.arch.string}.exe" failonerror="yes" dir="${java.io.tmpdir}">
       <arg value="--jdkhome"/>
       <arg file="${tryme.jdkhome}"/>
       <arg value="--userdir"/>
@@ -1004,7 +1017,7 @@ It is possible to use -Ddebug.port=3234 -Ddebug.pause=y to start the system in d
       <arg line="${run.args.ide}"/>
     </exec>
     <exec osfamily="unix" executable="sh" failonerror="yes" dir="${java.io.tmpdir}">
-      <arg value="${netbeans.dest.dir}/bin/netbeans"/>
+      <arg value="${tryme.launcher.prefix}"/>
       <arg value="--jdkhome"/>
       <arg file="${tryme.jdkhome}"/>
       <arg value="--userdir"/>
@@ -1812,7 +1825,7 @@ It is possible to use -Ddebug.port=3234 -Ddebug.pause=y to start the system in d
 
     <!-- #42157 - Scans all xml layers for OptionsExport folder and creates
     list of include/exclude patterns for import on the first start.  -->
-    <target name="create-netbeans-import">
+    <target name="create-netbeans-import" depends="-check-nb-cluster" if="has.nb.cluster">
         <taskdef name="optionsimport" classname="org.netbeans.nbbuild.LayerOptionsImport" classpath="${nbantext.jar}"/>
         <mkdir dir="${netbeans.dest.dir}/etc"/>
         <optionsimport output="${netbeans.dest.dir}/etc/netbeans.import">


### PR DESCRIPTION
…rm (only platform/lib/nbexec platform launchers exist).

"ant tryme" should still work, by invoking the nbexec.