### PR TITLE
Let the Travis build really fail on Rat or verify-libs-and-licenses f…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ language: java
 jdk:
   - oraclejdk8
 script:
-  - ant -quiet rat -Dcluster.config=platform
+  - (ant -quiet -Dcluster.config=platform build-source-config && mkdir scratch && cd scratch && unzip -qq ../nbbuild/build/platform-src* && ant -quiet rat -Dcluster.config=platform -Drat-report.haltonfailure=true && cd .. && rm -rf scratch)
   - ant -quiet build -Djavac.compilerargs=-nowarn -Dbuild.compiler.deprecation=false
   - ant -quiet test -Djavac.compilerargs=-nowarn -Dbuild.compiler.deprecation=false -Dtest.includes=NoTestsJustBuild
-  - ant -quiet verify-libs-and-licenses -Dcluster.config=platform
+  - ant -quiet verify-libs-and-licenses -Dcluster.config=platform -Dverify-libs-and-licenses.haltonfailure=true

--- a/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/VerifyLibsAndLicenses.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/VerifyLibsAndLicenses.java
@@ -45,6 +45,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import java.util.zip.CRC32;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
@@ -70,6 +71,12 @@ public class VerifyLibsAndLicenses extends Task {
         this.reportFile = report;
     }
 
+    private boolean haltonfailure;
+    /** JUnit-format XML result file to generate, rather than halting the build. */
+    public void setHaltonfailure(boolean haltonfailure) {
+        this.haltonfailure = haltonfailure;
+    }
+
     private Map<String,String> pseudoTests;
     private Set<String> modules;
 
@@ -89,6 +96,11 @@ public class VerifyLibsAndLicenses extends Task {
             throw new BuildException(x, getLocation());
         }
         JUnitReportWriter.writeReport(this, null, reportFile, pseudoTests);
+        if (haltonfailure && pseudoTests.values().stream().anyMatch(err -> err != null)) {
+            throw new BuildException("Failed VerifyLibsAndLicenses test(s):\n" +
+                                     pseudoTests.values().stream().filter(err -> err != null).collect(Collectors.joining("\n")),
+                                     getLocation());
+        }
         } catch (NullPointerException x) {x.printStackTrace(); throw x;}
     }
 

--- a/nbbuild/build.xml
+++ b/nbbuild/build.xml
@@ -1474,12 +1474,14 @@ It is possible to use -Ddebug.port=3234 -Ddebug.pause=y to start the system in d
 
     <target name="verify-all-libs-and-licenses" depends="bootstrap,download-all-extbins" description="Verify the contents of third-party libraries and licenses.">
         <taskdef name="verifylibsandlicenses" classname="org.netbeans.nbbuild.extlibs.VerifyLibsAndLicenses" classpath="${nbantext.jar}"/>
-        <verifylibsandlicenses report="${nb.build.dir}/verifylibsandlicenses.xml" nball=".."/>
+        <property name="verify-libs-and-licenses.haltonfailure" value="false" />
+        <verifylibsandlicenses report="${nb.build.dir}/verifylibsandlicenses.xml" nball=".." haltonfailure="${verify-libs-and-licenses.haltonfailure}" />
     </target>
 
     <target name="verify-libs-and-licenses" depends="bootstrap,download-selected-extbins" description="Verify the contents of third-party libraries and licenses in the selected configuration.">
         <taskdef name="verifylibsandlicenses" classname="org.netbeans.nbbuild.extlibs.VerifyLibsAndLicenses" classpath="${nbantext.jar}"/>
-        <verifylibsandlicenses report="${nb.build.dir}/verifylibsandlicenses.xml" nball=".."/>
+        <property name="verify-libs-and-licenses.haltonfailure" value="false" />
+        <verifylibsandlicenses report="${nb.build.dir}/verifylibsandlicenses.xml" nball=".." haltonfailure="${verify-libs-and-licenses.haltonfailure}" />
     </target>
 
     <target name="create-mandatory-files-for-binary" depends="bootstrap,download-selected-extbins" description="Create a summary of the licenses used by libraries in the build.">
@@ -2117,6 +2119,7 @@ It is possible to use -Ddebug.port=3234 -Ddebug.pause=y to start the system in d
             <exclude name="o.apache.tools.ant.module/release/VERSION.txt" /> <!--generated file-->
             <exclude name="o.apache.tools.ant.module/src/org/apache/tools/ant/module/resources/CustomTask_java" /> <!-- user visible file template -->
             <exclude name="o.apache.tools.ant.module/src/org/apache/tools/ant/module/resources/Project.xml_" /> <!-- user visible file template -->
+            <exclude name="o.n.bootstrap/readme/*.txt" /> <!--READMEs-->
             <exclude name="o.n.bootstrap/test/unit/src/org/fakepkg/resource1.txt" /> <!--no degree of creativity-->
             <exclude name="o.n.bootstrap/test/unit/src/org/fakepkg/resource2.txt" /> <!--no degree of creativity-->
             <exclude name="o.n.core/licenses/**" /> <!-- license files -->
@@ -2222,9 +2225,10 @@ It is possible to use -Ddebug.port=3234 -Ddebug.pause=y to start the system in d
                 <patternset refid="non.rat" />
             </fileset>
         </rat:report>
-        <taskdef name="rattohtml" classname="org.netbeans.nbbuild.RatReportTask" classpath="${build.ant.classes.dir}"/>
+        <taskdef name="rattotest" classname="org.netbeans.nbbuild.RatReportTask" classpath="${build.ant.classes.dir}"/>
         <loadproperties srcFile="cluster.properties" />
-        <rattohtml source="build/rat-report.xml" report="${nb.build.dir}/rat/"/>
+        <property name="rat-report.haltonfailure" value="false" />
+        <rattotest source="build/rat-report.xml" report="${nb.build.dir}/rat/" haltonfailure="${rat-report.haltonfailure}" />
     </target>
 
 </project>


### PR DESCRIPTION
…ailures.

Trying to make sure that Rat/verify-libs-and-licenses will actually break the build.

For Rat, this is a little bit more complex, as the Rat runs for all sources only (which in the end seemed reasonable), while it so far passes only for the platform. So creating the source zip, unpacking it and running rat on that limited sources only. Will be simpler when Rat passes for the whole repository.