### PR TITLE
[NETBEANS-149] Max heap size removed

### DIFF
--- a/apisupport.harness/release/etc/app.conf
+++ b/apisupport.harness/release/etc/app.conf
@@ -21,7 +21,7 @@ default_mac_userdir="${HOME}/Library/Application Support/${APPNAME}/dev"
 
 # options used by the launcher by default, can be overridden by explicit
 # command line switches
-default_options="--branding ${branding.token} -J-Xms24m -J-Xmx64m"
+default_options="--branding ${branding.token}"
 # for development purposes you may wish to append: -J-Dnetbeans.logger.console=true -J-ea
 
 # default location of JDK/JRE, can be overridden by using --jdkhome <dir> switch


### PR DESCRIPTION
Explicit max and min heap size settings removed.

This file (changed in this PR) is the default `.conf` file your application will get when you create an application on top of NetBeans Platform.

See [NETBEANS-149](https://issues.apache.org/jira/browse/NETBEANS-149) for details.