### PR TITLE
Permit CLI --open-group to accept a substring of a group name as a convenience

### DIFF
--- a/projectui/src/org/netbeans/modules/project/ui/groups/GroupOptionProcessor.java
+++ b/projectui/src/org/netbeans/modules/project/ui/groups/GroupOptionProcessor.java
@@ -19,13 +19,7 @@
 
 package org.netbeans.modules.project.ui.groups;
 
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import java.io.PrintStream;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
-import org.netbeans.api.project.Project;
-import org.netbeans.api.project.ui.OpenProjects;
 import org.netbeans.api.sendopts.CommandException;
 import org.netbeans.spi.sendopts.Env;
 import org.openide.util.NbBundle.Messages;
@@ -33,8 +27,6 @@ import static org.netbeans.modules.project.ui.groups.Bundle.*;
 import org.netbeans.spi.sendopts.Arg;
 import org.netbeans.spi.sendopts.Description;
 import org.netbeans.spi.sendopts.ArgsProcessor;
-import org.openide.util.Exceptions;
-import org.openide.util.RequestProcessor;
 
 public class GroupOptionProcessor implements ArgsProcessor {
     @Arg(longName="open-group")
@@ -44,7 +36,7 @@ public class GroupOptionProcessor implements ArgsProcessor {
     )
     @Messages({
         "GroupOptionProcessor.open.name=--open-group NAME",
-        "GroupOptionProcessor.open.desc=open a project group by name"
+        "GroupOptionProcessor.open.desc=open a project group by ID or name (or unique substring)"
     })
     public String openOption;
     @Arg(longName="close-group")
@@ -68,14 +60,26 @@ public class GroupOptionProcessor implements ArgsProcessor {
     })
     @Override public void process(Env env) throws CommandException {
         if (openOption != null) {
+            Group found = null;
             for (Group g : Group.allGroups()) {
                 if (g.id.equals(openOption) || g.getName().equals(openOption)) {
-                    supressWinsysLazyLoading();
-                    Group.setActiveGroup(g, false);
-                    return;
+                    found = g;
+                    break;
                 }
             }
-            throw new CommandException(2, GroupOptionProcessor_no_such_group(openOption));
+            if (found == null) {
+                for (Group g : Group.allGroups()) {
+                    if (g.id.contains(openOption) || g.getName().contains(openOption)) {
+                        found = g;
+                        break;
+                    }
+                }
+            }
+            if (found == null) {
+                throw new CommandException(2, GroupOptionProcessor_no_such_group(openOption));
+            }
+            supressWinsysLazyLoading();
+            Group.setActiveGroup(found, false);
         } else if (closeOption) {
             supressWinsysLazyLoading();
             Group.setActiveGroup(null, false);

--- a/projectui/src/org/netbeans/modules/project/ui/groups/GroupOptionProcessor.java
+++ b/projectui/src/org/netbeans/modules/project/ui/groups/GroupOptionProcessor.java
@@ -36,7 +36,7 @@ public class GroupOptionProcessor implements ArgsProcessor {
     )
     @Messages({
         "GroupOptionProcessor.open.name=--open-group NAME",
-        "GroupOptionProcessor.open.desc=open a project group by ID or name (or unique substring)"
+        "GroupOptionProcessor.open.desc=open a project group by shortened or full name (or unique substring)"
     })
     public String openOption;
     @Arg(longName="close-group")


### PR DESCRIPTION
Should be self-explanatory. Tested manually on a simple case with a couple of groups

```sh
ant tryme -Dtryme.arg.open='--open-group "…ID or name or substring…"'
```

since I could find no automated test for this comparable to `OpenCLITest`.